### PR TITLE
chore: post-release cleanup — restore CI scaffolding, downgrade to 0.16.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,6 +354,8 @@ scripts/archive/
 scripts/ai_assistant/dev/
 # Internal planning workflow artifacts — design docs are in docs/sphinx/
 docs/plan/
+# Internal audit / review notes (kept locally, not committed)
+audit/
 # Development prompt templates
 docs/prompts/
 # Tool-generated planning artifacts

--- a/README.md
+++ b/README.md
@@ -494,10 +494,10 @@ uv run python main.py --version
 
 | Commit Message | Version Bump | Example |
 |----------------|--------------|---------|
-| `fix: ...` | **Patch** | 0.16.0 → 0.16.1 |
-| `feat: ...` | **Minor** | 0.16.0 → 0.17.0 |
-| `feat!: ...` or `BREAKING CHANGE:` | **Major** | 0.16.0 → 1.0.0 |
-| Other (docs, chore, refactor, style, test) | **No bump** | 0.16.0 (unchanged) |
+| `fix: ...` | **Patch** | 0.16.1 → 0.16.2 |
+| `feat: ...` | **Minor** | 0.16.1 → 0.17.0 |
+| `feat!: ...` or `BREAKING CHANGE:` | **Major** | 0.16.1 → 1.0.0 |
+| Other (docs, chore, refactor, style, test) | **No bump** | 0.16.1 (unchanged) |
 
 **Via Git hooks (automatic):** commit normally — the post-commit hook analyses
 the message and bumps the version automatically:

--- a/README.md
+++ b/README.md
@@ -659,4 +659,4 @@ details.
 
 ---
 
-**Version**: 1.0.0 | **Status**: Beta (Active Development — Single-Study Mode)
+**Version**: 0.16.1 | **Status**: Beta (Active Development — Single-Study Mode)

--- a/__version__.py
+++ b/__version__.py
@@ -28,7 +28,7 @@ __all__ = ["__version__", "__version_info__"]
 # Semantic Versioning normal version: X.Y.Z with no leading zeroes except zero itself.
 _SEMVER_CORE_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
-__version__: str = "1.0.0"
+__version__: str = "0.16.1"
 """Canonical repository version in ``MAJOR.MINOR.PATCH`` form."""
 
 _match = _SEMVER_CORE_RE.fullmatch(__version__)

--- a/docs/sphinx/developer_guide/versioning.rst
+++ b/docs/sphinx/developer_guide/versioning.rst
@@ -15,7 +15,7 @@ The canonical version lives in ``__version__.py`` at the repository root:
 
 .. code-block:: python
 
-   __version__: str = "0.16.0"
+   __version__: str = "0.16.1"
 
 All other modules import from this single source:
 

--- a/scripts/ai_assistant/ui/chat.py
+++ b/scripts/ai_assistant/ui/chat.py
@@ -136,7 +136,7 @@ def composer(assistant_slot: Any | None = None) -> None:
                 )
                 submitted = st.form_submit_button(
                     _submit_glyph,
-                    use_container_width=False,
+                    width="content",
                     disabled=bool(pending_stream),
                     help=("Response in progress" if pending_stream else None),
                 )
@@ -395,7 +395,7 @@ def _render_model_pill() -> None:
                 '<div class="rpln-adaptive-sentinel-on" style="display:none;"></div>',
                 unsafe_allow_html=True,
             )
-        pop = st.popover(_pretty_model_label_compact(current_model), use_container_width=False)
+        pop = st.popover(_pretty_model_label_compact(current_model), width="content")
     more_open = bool(st.session_state.get("rpln_model_more_open", False))
     with pop:
         st.markdown(
@@ -448,12 +448,12 @@ def _render_model_pill() -> None:
             st.markdown('<hr class="rpln-popover-sep" />', unsafe_allow_html=True)
 
             if st.button(
-                "More models  \u203a", key="rpln_more_models_toggle", use_container_width=True
+                "More models  \u203a", key="rpln_more_models_toggle", width="stretch"
             ):
                 st.session_state.rpln_model_more_open = True
                 st.rerun()
         else:
-            if st.button("\u2039  Models", key="rpln_more_models_back", use_container_width=True):
+            if st.button("\u2039  Models", key="rpln_more_models_back", width="stretch"):
                 st.session_state.rpln_model_more_open = False
                 st.rerun()
             st.markdown('<hr class="rpln-popover-sep" />', unsafe_allow_html=True)
@@ -461,7 +461,7 @@ def _render_model_pill() -> None:
                 if model == current_model:
                     continue
                 name = _pretty_model_label(model)
-                if st.button(name, key=f"model_pill_{model}", use_container_width=True):
+                if st.button(name, key=f"model_pill_{model}", width="stretch"):
                     _set_chat_model(model)
                     st.session_state.rpln_model_more_open = False
                     st.rerun()
@@ -471,15 +471,15 @@ def _render_composer_plus_menu() -> None:
     """Render the `+` popover (Upload file / Upload folder)."""
     with (
         st.container(key="rpln_composer_plus"),
-        st.popover("+", use_container_width=False),
+        st.popover("+", width="content"),
     ):
         st.markdown(
             '<div class="rpln-plus-menu-header">Attach</div>',
             unsafe_allow_html=True,
         )
-        if st.button("Upload file", key="rpln_plus_upload_file", use_container_width=True):
+        if st.button("Upload file", key="rpln_plus_upload_file", width="stretch"):
             st.session_state["rpln_plus_upload_mode"] = "file"
-        if st.button("Upload folder", key="rpln_plus_upload_folder", use_container_width=True):
+        if st.button("Upload folder", key="rpln_plus_upload_folder", width="stretch"):
             st.session_state["rpln_plus_upload_mode"] = "folder"
 
     mode = st.session_state.get("rpln_plus_upload_mode")

--- a/scripts/ai_assistant/ui/shell.py
+++ b/scripts/ai_assistant/ui/shell.py
@@ -104,7 +104,7 @@ def topbar() -> None:
             )
             with st.popover(
                 title_label,
-                use_container_width=False,
+                width="content",
                 disabled=not has_messages,
                 help=(
                     title
@@ -140,7 +140,7 @@ def topbar() -> None:
                         if save_col.button(
                             "Save",
                             key=f"rpln_topbar_rename_save_{conv_id}",
-                            use_container_width=True,
+                            width="stretch",
                         ):
                             new_title = (ss.get(rename_key) or "").strip()
                             if new_title:
@@ -151,7 +151,7 @@ def topbar() -> None:
                         if cancel_col.button(
                             "Cancel",
                             key=f"rpln_topbar_rename_cancel_{conv_id}",
-                            use_container_width=True,
+                            width="stretch",
                         ):
                             ss[rename_mode_key] = "menu"
                             st.rerun()
@@ -163,14 +163,14 @@ def topbar() -> None:
                         if st.button(
                             "Rename",
                             key=f"rpln_topbar_rename_open_{conv_id}",
-                            use_container_width=True,
+                            width="stretch",
                         ):
                             ss[rename_mode_key] = "rename"
                             st.rerun()
                         if st.button(
                             ("\u2605 Unstar" if is_pinned else "\u2606 Star"),
                             key=f"rpln_topbar_pin_{conv_id}",
-                            use_container_width=True,
+                            width="stretch",
                         ):
                             _toggle_pin(conv_id)
                             ss[rename_mode_key] = "menu"
@@ -178,7 +178,7 @@ def topbar() -> None:
                         if st.button(
                             "Delete",
                             key=f"rpln_topbar_delete_{conv_id}",
-                            use_container_width=True,
+                            width="stretch",
                         ):
                             _delete_conversation(conv_id)
                             ss[rename_mode_key] = "menu"
@@ -189,7 +189,7 @@ def topbar() -> None:
 
         with st.container(key="rpln_topbar_share"), st.popover(
             "Share",
-            use_container_width=False,
+            width="content",
             disabled=not has_messages,
             help=(
                 "Share and export"
@@ -213,7 +213,7 @@ def topbar() -> None:
                     file_name=f"{conv_id[:8]}.md",
                     mime="text/markdown",
                     key=f"rpln_share_export_md_{conv_id}",
-                    use_container_width=True,
+                    width="stretch",
                 )
                 st.download_button(
                     "Plain text (.txt)",
@@ -221,7 +221,7 @@ def topbar() -> None:
                     file_name=f"{conv_id[:8]}.txt",
                     mime="text/plain",
                     key=f"rpln_share_export_txt_{conv_id}",
-                    use_container_width=True,
+                    width="stretch",
                 )
             else:
                 st.caption("Start a chat to enable sharing.")

--- a/scripts/ai_assistant/ui/streaming.py
+++ b/scripts/ai_assistant/ui/streaming.py
@@ -314,7 +314,7 @@ def _render_markdown_table(table_lines: list[str], *, key: str) -> None:
             file_name=f"table_result_{key}.csv",
             mime="text/csv",
         )
-        st.dataframe(df, use_container_width=True, hide_index=True)
+        st.dataframe(df, width="stretch", hide_index=True)
     except Exception:
         # Fallback to markdown rendering
         st.markdown("\n".join(table_lines))
@@ -340,7 +340,7 @@ def _render_plotly_figure(fig_path: Path, *, msg_idx: int = 0, fig_idx: int = 0)
             file_name=f"interactive_chart_{fig_idx}.json",
             mime="application/json",
         )
-        st.plotly_chart(fig, use_container_width=True, key=f"plotly_{msg_idx}_{fig_idx}")
+        st.plotly_chart(fig, width="stretch", key=f"plotly_{msg_idx}_{fig_idx}")
     except Exception as _chart_exc:
         st.warning(
             f"**Chart render failed** (`{type(_chart_exc).__name__}`): {_chart_exc}",
@@ -850,7 +850,7 @@ def _render_message_content(
                     file_name=file_name,
                     mime=mime,
                 )
-                st.image(str(artifact_path), use_container_width=True)
+                st.image(str(artifact_path), width="stretch")
             else:
                 st.warning(
                     "**Figure file not found.**  \n"

--- a/scripts/ai_assistant/ui/wizard.py
+++ b/scripts/ai_assistant/ui/wizard.py
@@ -317,7 +317,7 @@ def render_setup_page() -> None:
                     "Next →",
                     type="primary",
                     disabled=not key_ok,
-                    use_container_width=True,
+                    width="stretch",
                 ):
                     st.session_state.llm_provider_label = provider_label
                     st.session_state.api_key_saved = api_key
@@ -360,7 +360,7 @@ def render_setup_page() -> None:
                 if st.button(
                     run_label,
                     type="secondary" if pipeline_ready else "primary",
-                    use_container_width=True,
+                    width="stretch",
                 ):
                     with st.spinner("Loading study data — this may take a minute…"):
                         result = run_pipeline()
@@ -375,7 +375,7 @@ def render_setup_page() -> None:
                 if (
                     output_exists
                     and not pipeline_ready
-                    and st.button("Use Existing Data", use_container_width=True)
+                    and st.button("Use Existing Data", width="stretch")
                 ):
                     st.session_state.pipeline_ready = True
                     st.rerun()
@@ -388,7 +388,7 @@ def render_setup_page() -> None:
 
                 col_back, col_next = st.columns(2)
                 with col_back:
-                    if st.button("← Back", use_container_width=True):
+                    if st.button("← Back", width="stretch"):
                         st.session_state.wizard_step = 1
                         st.rerun()
                 with col_next:
@@ -396,7 +396,7 @@ def render_setup_page() -> None:
                         "Next →",
                         type="primary",
                         disabled=not st.session_state.pipeline_ready,
-                        use_container_width=True,
+                        width="stretch",
                     ):
                         st.session_state.wizard_step = 3
                         st.rerun()
@@ -419,13 +419,13 @@ def render_setup_page() -> None:
                 if st.button(
                     "Start Chatting →",
                     type="primary",
-                    use_container_width=True,
+                    width="stretch",
                 ):
                     st.session_state.setup_complete = True
                     # WP-F.05.01 — flip redesign gate on wizard exit.
                     st.session_state.chat_started = True
                     st.rerun()
 
-                if st.button("← Back", use_container_width=True):
+                if st.button("← Back", width="stretch"):
                     st.session_state.wizard_step = 2
                     st.rerun()

--- a/scripts/ai_assistant/web_ui.py
+++ b/scripts/ai_assistant/web_ui.py
@@ -214,7 +214,7 @@ def _render_search_modal() -> None:
             with st.container(key=f"rpln_search_row_{cid}"):
                 col_title, col_ts = st.columns([8, 2], gap="small")
                 with col_title:
-                    if st.button(title, key=f"rpln_search_result_{cid}", use_container_width=True):
+                    if st.button(title, key=f"rpln_search_result_{cid}", width="stretch"):
                         _save_conversation()
                         # _load_conversation populates session state directly +
                         # resets the agent on success; nothing further to do.
@@ -484,7 +484,7 @@ def _render_export_submenu(conv_id: str) -> None:
     """Popover with export download buttons for a conversation."""
     import importlib.util
 
-    with st.popover("↓", use_container_width=False):
+    with st.popover("↓", width="content"):
         st.markdown("**Export**")
         st.download_button(
             "Download as .txt",


### PR DESCRIPTION
## Summary

Cleanup pass after the initial v1.0.0 commit. Restores accidentally deleted files in the working tree, reconciles the version mismatch between the commit message and `__version__.py`, and migrates the Streamlit UI to the new `width=` API.

## Changes

**Restored from HEAD** (no diff in this PR — files were re-added to working tree before commit):
- `.gitignore`, `.env.example`, `.streamlit/config.toml`, `.github/workflows/*` (4 workflows)

**Modified:**
- `__version__.py` + README badge: `1.0.0` → `0.16.1` — the v1.0.0 tag was premature; this aligns with the README's "Beta" status. v1.0.0 is now a future milestone gated on Phase 2 hardening (LLM-Python sandbox subprocess isolation, removing API keys from `os.environ`, adversarial tests for `phi_safe.guard_user_prompt`).
- `.gitignore`: added top-level `audit/` directory pattern, matching the original release-commit intent of excluding internal review notes.
- `scripts/ai_assistant/ui/{chat,shell,streaming,wizard}.py` + `web_ui.py`: mechanical migration from deprecated `use_container_width=True/False` → `width="stretch"/"content"` (Streamlit 1.36+).

## Test plan

- [ ] `ci.yml` workflow passes (lint + typecheck + tests)
- [ ] `docs-quality-check.yml` passes
- [ ] `auto-version.yml` does not bump version (this PR is `chore:`, not `feat:`/`fix:`)
- [ ] Manual: launch Streamlit UI, confirm chat composer / popovers / wizard render correctly with new `width=` API