### PR TITLE
feat(security): keys out of os.environ + log_hygiene API-key redaction

### DIFF
--- a/scripts/ai_assistant/agent_graph.py
+++ b/scripts/ai_assistant/agent_graph.py
@@ -57,10 +57,22 @@ def _build_llm(provider: str, model: str) -> Any:
     Factored out of :func:`_init_llm` so the ladder walker can re-construct
     the client with different model names without duplicating the NVIDIA
     / init_chat_model fork.
+
+    The API key is passed as an explicit ``api_key=`` kwarg from the
+    KeyStore — the SDK auto-pickup from ``os.environ`` is no longer
+    relied on, because PR #3 keeps keys out of the parent's env.
     """
     from langchain.chat_models import init_chat_model  # type: ignore[import-untyped]
 
+    from scripts.ai_assistant.keystore import (
+        get_keystore,
+        provider_slug_for,
+    )
+
     logger.debug("Initialising LLM: provider=%s, model=%s", provider, model)
+
+    slug = provider_slug_for(provider)
+    api_key = get_keystore().get(slug) if slug else None
 
     # NVIDIA AI Endpoints requires langchain_nvidia_ai_endpoints.ChatNVIDIA.
     # init_chat_model does not support the NVIDIA provider directly and the
@@ -74,20 +86,26 @@ def _build_llm(provider: str, model: str) -> Any:
                 "langchain-nvidia-ai-endpoints is not installed. "
                 "Run: uv add langchain-nvidia-ai-endpoints"
             ) from exc
-        return ChatNVIDIA(
-            model=model,
-            max_tokens=config.AGENT_MAX_TOKENS,
-            temperature=1,
-            top_p=1,
-        )
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "max_tokens": config.AGENT_MAX_TOKENS,
+            "temperature": 1,
+            "top_p": 1,
+        }
+        if api_key:
+            kwargs["api_key"] = api_key
+        return ChatNVIDIA(**kwargs)
 
     try:
-        return init_chat_model(
-            model=model,
-            model_provider=provider,
-            max_tokens=config.AGENT_MAX_TOKENS,
-            timeout=config.AGENT_TIMEOUT,
-        )
+        kwargs = {
+            "model": model,
+            "model_provider": provider,
+            "max_tokens": config.AGENT_MAX_TOKENS,
+            "timeout": config.AGENT_TIMEOUT,
+        }
+        if api_key:
+            kwargs["api_key"] = api_key
+        return init_chat_model(**kwargs)
     except Exception as exc:
         # Wrap with context so callers get a clear actionable message.
         raise RuntimeError(

--- a/scripts/ai_assistant/cli.py
+++ b/scripts/ai_assistant/cli.py
@@ -41,11 +41,20 @@ def _select_llm() -> None:
     print("\nSelect LLM provider:")
     print(f"  Current: {config.LLM_PROVIDER} / {config.LLM_MODEL}\n")
 
+    from scripts.ai_assistant.keystore import get_keystore, provider_slug_for
+
+    keystore = get_keystore()
+
     for num, (provider_id, label, env_key, _default_model) in _PROVIDER_CHOICES.items():
         marker = " ←" if provider_id == config.LLM_PROVIDER else ""
         key_status = ""
         if env_key:
-            has_key = bool(os.environ.get(env_key, ""))
+            slug = provider_slug_for(provider_id)
+            # "Set" means: KeyStore has it OR the user pre-exported it in their
+            # shell. We never write to ``os.environ`` ourselves anymore.
+            has_key = (slug is not None and keystore.has(slug)) or bool(
+                os.environ.get(env_key, "")
+            )
             key_status = " (key set)" if has_key else " (key needed)"
         print(f"  {num}. {label}{key_status}{marker}")
 
@@ -65,9 +74,13 @@ def _select_llm() -> None:
 
     provider_id, label, env_key, default_model = _PROVIDER_CHOICES[choice]
 
-    # API key
+    # API key — stored in the KeyStore (in-process memory), never in os.environ.
     if env_key:
-        existing_key = os.environ.get(env_key, "")
+        slug = provider_slug_for(provider_id)
+        existing_key = (
+            (slug is not None and keystore.get(slug))
+            or os.environ.get(env_key, "")
+        )
         if existing_key:
             print(f"  {env_key} is already set.")
             try:
@@ -77,8 +90,8 @@ def _select_llm() -> None:
                 return
             if update in ("y", "yes"):
                 new_key = getpass.getpass(f"  {env_key}: ").strip()
-                if new_key:
-                    os.environ[env_key] = new_key
+                if new_key and slug is not None:
+                    keystore.set(slug, new_key)
         else:
             try:
                 new_key = getpass.getpass(f"  {env_key}: ").strip()
@@ -87,8 +100,8 @@ def _select_llm() -> None:
                 return
             if not new_key:
                 print(f"  ⚠ No API key provided for {label}. Queries may fail.")
-            else:
-                os.environ[env_key] = new_key
+            elif slug is not None:
+                keystore.set(slug, new_key)
 
     # Model
     current_model = config.LLM_MODEL if provider_id == config.LLM_PROVIDER else default_model

--- a/scripts/ai_assistant/keystore.py
+++ b/scripts/ai_assistant/keystore.py
@@ -1,0 +1,164 @@
+"""In-memory API-key registry.
+
+Replaces the prior pattern of writing user-entered LLM API keys to
+``os.environ`` (so any sibling process or sandboxed Python could read
+them) with a process-local registry held in Streamlit session state.
+
+The trust boundary is straightforward: keys live ONLY here in memory
+and are passed explicitly to LangChain client constructors via
+``api_key=``. The single narrow exception is when the wizard launches
+the pipeline as a subprocess that needs ``ANTHROPIC_API_KEY`` /
+``GOOGLE_API_KEY`` for vision-API calls — :meth:`KeyStore.env_for_subprocess`
+returns a *new* dict suitable for ``subprocess.run(env=...)`` without
+ever mutating the parent's ``os.environ``.
+
+See ``docs/sphinx/developer_guide/sandbox.rst`` for the threat model.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Iterable
+
+
+# Provider slug → conventional environment-variable name LangChain SDKs
+# auto-pick. The names here are the SDK contract; they are NOT the only
+# place keys live (see ``KeyStore`` itself), but when keys DO need to
+# transit env (e.g. for the pipeline subprocess), this is the mapping.
+ENV_VAR_BY_PROVIDER: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "nvidia": "NVIDIA_API_KEY",
+}
+
+
+class KeyStore:
+    """Process-local registry of LLM provider API keys.
+
+    Instances are intended to be held in :data:`streamlit.session_state`
+    via :func:`get_keystore`; for non-Streamlit contexts (CLI, tests) a
+    fresh instance is fine — the class itself has no global state.
+
+    Keys live in a private dict on the instance. They are never written
+    to disk, never copied to ``os.environ`` by this class, and never
+    logged (the redaction patterns in ``scripts.utils.log_hygiene``
+    catch any accidental leak in log output).
+    """
+
+    __slots__ = ("_keys",)
+
+    def __init__(self) -> None:
+        self._keys: dict[str, str] = {}
+
+    @staticmethod
+    def _normalise(provider: str) -> str:
+        return provider.strip().lower()
+
+    def _ensure_known(self, provider: str) -> str:
+        slug = self._normalise(provider)
+        if slug not in ENV_VAR_BY_PROVIDER:
+            raise ValueError(
+                f"Unknown provider {provider!r}. "
+                f"Known: {sorted(ENV_VAR_BY_PROVIDER)}."
+            )
+        return slug
+
+    def set(self, provider: str, key: str) -> None:
+        """Store ``key`` for ``provider``. Raises if provider is unknown."""
+        slug = self._ensure_known(provider)
+        if not key or not key.strip():
+            raise ValueError(f"Refusing to store an empty key for {provider!r}.")
+        self._keys[slug] = key
+
+    def get(self, provider: str) -> str | None:
+        """Return the stored key for ``provider`` or ``None``."""
+        return self._keys.get(self._normalise(provider))
+
+    def has(self, provider: str) -> bool:
+        return self._normalise(provider) in self._keys
+
+    def clear(self, provider: str | None = None) -> None:
+        """Forget one provider's key (or all if ``provider`` is omitted).
+
+        This only touches the instance's in-memory dict. It does NOT
+        touch ``os.environ`` — if the user pre-set a shell env var, that
+        remains the user's choice and lives in their shell's session.
+        """
+        if provider is None:
+            self._keys.clear()
+            return
+        self._keys.pop(self._normalise(provider), None)
+
+    def env_for_subprocess(self, providers: Iterable[str]) -> dict[str, str]:
+        """Build an env dict suitable for ``subprocess.run(env=...)``.
+
+        Returns a *new* dict containing ``{ENV_VAR: key}`` for each
+        requested provider that has a key set. Providers without a
+        stored key are skipped (the caller decides whether that's an
+        error). Unknown providers raise ``ValueError`` immediately.
+
+        This method is the ONLY place keys leave the KeyStore in an
+        env-shaped form. The returned dict is a pure value — neither
+        ``os.environ`` nor the KeyStore is mutated.
+        """
+        out: dict[str, str] = {}
+        for provider in providers:
+            slug = self._ensure_known(provider)
+            key = self._keys.get(slug)
+            if key is not None:
+                out[ENV_VAR_BY_PROVIDER[slug]] = key
+        return out
+
+
+# LangChain ``model_provider`` strings → KeyStore slug. Centralised here so
+# the wizard / agent_graph / cli all map identically.
+_LANGCHAIN_PROVIDER_TO_SLUG: dict[str, str] = {
+    "anthropic": "anthropic",
+    "openai": "openai",
+    "google-genai": "google",
+    "google": "google",
+    "gemini": "google",
+    "nvidia-ai-endpoints": "nvidia",
+    "nvidia": "nvidia",
+}
+
+
+def provider_slug_for(langchain_provider: str) -> str | None:
+    """Map a LangChain ``model_provider`` string to a KeyStore slug.
+
+    Returns ``None`` for providers that don't take an API key (e.g.
+    ``ollama``) so callers can short-circuit.
+    """
+    return _LANGCHAIN_PROVIDER_TO_SLUG.get(langchain_provider.strip().lower())
+
+
+_PROCESS_KEYSTORE: KeyStore | None = None
+
+
+def get_keystore() -> KeyStore:
+    """Return the KeyStore for the current Streamlit session.
+
+    In Streamlit: persisted via ``st.session_state``.
+    Outside Streamlit (CLI, scripts): cached on a module global so a single
+    process sees one consistent KeyStore across calls.
+    Unit tests that want isolation should construct ``KeyStore()`` directly.
+    """
+    try:
+        import streamlit as st
+
+        ss = st.session_state
+    except (ImportError, RuntimeError):
+        global _PROCESS_KEYSTORE
+        if _PROCESS_KEYSTORE is None:
+            _PROCESS_KEYSTORE = KeyStore()
+        return _PROCESS_KEYSTORE
+
+    existing = ss.get("rpln_keystore")
+    if isinstance(existing, KeyStore):
+        return existing
+    fresh = KeyStore()
+    ss["rpln_keystore"] = fresh
+    return fresh

--- a/scripts/ai_assistant/ui/wizard.py
+++ b/scripts/ai_assistant/ui/wizard.py
@@ -63,17 +63,40 @@ def inject_wizard_css() -> None:
 # ---------------------------------------------------------------------------
 
 def apply_llm_config(provider_label: str, api_key: str, model: str) -> None:
-    """Set env var, patch config module, reset agent singleton."""
+    """Persist provider/model selection + stash the API key in the KeyStore.
+
+    The non-secret bits (LLM_PROVIDER, LLM_MODEL) still live in env vars
+    + the config module so the rest of the app can read them at any time.
+    The API key goes into the in-memory ``KeyStore`` only — never into
+    ``os.environ``. ``agent_graph._build_llm`` reads it from there at
+    client-construction time and passes it as ``api_key=`` explicitly.
+    """
     import os
 
+    from scripts.ai_assistant.keystore import (
+        get_keystore,
+        provider_slug_for,
+    )
+
     cfg = _PROVIDER_CONFIG[provider_label]
-    env_var = cfg.get("env_var")
+
+    # Defensive: if a stale ``*_API_KEY`` was left in ``os.environ`` by a
+    # previous build of the app or by the user's shell, scrub it. We keep
+    # the user's *original* shell-set value separately readable through the
+    # password input (see step 1 of the wizard) but we never carry it into
+    # the running process env.
     for _pcfg in _PROVIDER_CONFIG.values():
         _ev = _pcfg.get("env_var")
-        if _ev and _ev != env_var:
+        if _ev:
             os.environ.pop(_ev, None)
-    if env_var and api_key:
-        os.environ[env_var] = api_key
+
+    if cfg["needs_key"] and api_key:
+        slug = provider_slug_for(cfg["provider"])
+        if slug is not None:
+            get_keystore().set(slug, api_key)
+
+    # Non-secret config remains in env + module attribute for compatibility
+    # with code paths that read it directly.
     os.environ["LLM_PROVIDER"] = cfg["provider"]
     os.environ["LLM_MODEL"] = model
     config.LLM_PROVIDER = cfg["provider"]  # type: ignore[attr-defined]
@@ -82,8 +105,20 @@ def apply_llm_config(provider_label: str, api_key: str, model: str) -> None:
 
 
 def ensure_llm_config() -> None:
-    """Re-apply LLM env vars on every rerun (survives hot-reload)."""
+    """Re-apply non-secret LLM env vars on every Streamlit rerun.
+
+    The KeyStore is persisted in ``st.session_state`` so keys survive
+    reruns automatically — this function only refreshes the non-secret
+    LLM_PROVIDER / LLM_MODEL env vars + module attributes. If the user
+    pasted a key on this rerun cycle it has already been routed through
+    :func:`apply_llm_config` → KeyStore.
+    """
     import os
+
+    from scripts.ai_assistant.keystore import (
+        get_keystore,
+        provider_slug_for,
+    )
 
     provider_label = st.session_state.get("llm_provider_label", _default_provider_label())
     api_key = st.session_state.get("api_key_saved", "")
@@ -91,13 +126,20 @@ def ensure_llm_config() -> None:
     if provider_label not in _PROVIDER_CONFIG:
         return
     cfg = _PROVIDER_CONFIG[provider_label]
-    env_var = cfg.get("env_var")
+
     for _pcfg in _PROVIDER_CONFIG.values():
         _ev = _pcfg.get("env_var")
-        if _ev and _ev != env_var:
+        if _ev:
             os.environ.pop(_ev, None)
-    if env_var and api_key:
-        os.environ[env_var] = api_key
+
+    # If the password input held a value but ``apply_llm_config`` was never
+    # called (e.g. coming back from a saved session), copy into the keystore
+    # now so ``agent_graph`` finds it.
+    if cfg["needs_key"] and api_key:
+        slug = provider_slug_for(cfg["provider"])
+        if slug is not None and not get_keystore().has(slug):
+            get_keystore().set(slug, api_key)
+
     os.environ["LLM_PROVIDER"] = cfg["provider"]
     os.environ["LLM_MODEL"] = model
     config.LLM_PROVIDER = cfg["provider"]  # type: ignore[attr-defined]
@@ -119,12 +161,35 @@ def _ensure_phi_key() -> None:
 
 
 def run_pipeline() -> dict[str, Any]:
+    """Run the data-extraction pipeline as a subprocess.
+
+    The pipeline's PDF-extraction step needs ``ANTHROPIC_API_KEY`` /
+    ``GOOGLE_API_KEY`` in its env to call vision APIs. Rather than leak
+    those into the parent's ``os.environ`` for the lifetime of the app,
+    we inject them only into this single subprocess call via the
+    KeyStore's ``env_for_subprocess`` helper. The parent's env stays
+    clean before, during, and after the call.
+    """
+    import os
+
+    from scripts.ai_assistant.keystore import (
+        ENV_VAR_BY_PROVIDER,
+        get_keystore,
+    )
+
     _ensure_phi_key()
+
+    subprocess_env = os.environ.copy()
+    subprocess_env.update(
+        get_keystore().env_for_subprocess(list(ENV_VAR_BY_PROVIDER))
+    )
+
     result = subprocess.run(  # noqa: S603
         [sys.executable, str(config.BASE_DIR / "main.py"), "--pipeline"],
         capture_output=True,
         text=True,
         cwd=str(config.BASE_DIR),
+        env=subprocess_env,
     )
     combined = (result.stdout + "\n" + result.stderr).strip()
     return {"success": result.returncode == 0, "output": combined}

--- a/scripts/utils/log_hygiene.py
+++ b/scripts/utils/log_hygiene.py
@@ -58,17 +58,42 @@ __all__ = [
 # on the high-confidence BLOCKING tier. A diverging per-module list is
 # actively dangerous — new PHI classes added to phi_patterns would silently
 # not be redacted in logs.
+API_KEY_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    # Anthropic keys: ``sk-ant-api03-…`` ~108 chars total. Require the
+    # ``api`` segment + a long body so ``sk-ant-foo`` shorthand in docs
+    # is not redacted.
+    ("ANTHROPIC_KEY", re.compile(r"sk-ant-[A-Za-z]+\d*-[A-Za-z0-9_\-]{20,}")),
+    # OpenAI keys: ``sk-…`` ≥40 chars body, optionally with ``proj-`` prefix.
+    ("OPENAI_KEY", re.compile(r"sk-(?:proj-)?[A-Za-z0-9]{40,}")),
+    # NVIDIA NGC keys.
+    ("NVIDIA_KEY", re.compile(r"nvapi-[A-Za-z0-9_\-]{30,}")),
+    # Google API keys (Gemini, GCP). Always start with ``AIza`` + 35 chars.
+    ("GOOGLE_KEY", re.compile(r"AIza[A-Za-z0-9_\-]{35}")),
+]
+"""LLM provider API-key patterns. After PR #3 the keystore keeps keys out
+of ``os.environ`` entirely, so keys never reach the logger via env-var
+dump. But defense in depth: if a key ever lands in a log message —
+through a stack trace, a tool call, or a copy-paste — these patterns
+scrub it before the message is written to ``.logs/``.
+
+Each pattern requires the full provider-specific length so short
+references like ``sk-flag`` or doc literals do NOT false-positive.
+"""
+
+
 _GENERIC_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    *API_KEY_PATTERNS,
     *BLOCKING_PATTERNS,
     *WARN_PATTERNS,
 ]
-"""Redaction catalog — aliased to :data:`phi_patterns.BLOCKING_PATTERNS` +
-:data:`phi_patterns.WARN_PATTERNS`.
+"""Redaction catalog — :data:`API_KEY_PATTERNS` first (so a key embedded
+inside a longer string is caught before any PHI heuristic might claim
+part of it), then :data:`phi_patterns.BLOCKING_PATTERNS` + WARN_PATTERNS.
 
 Applied IN ORDER to every log message by :class:`PHIRedactingFilter`. Each
-match is replaced with ``<CATEGORY>`` (e.g. ``<EMAIL>``). Intentionally
-conservative — false positives here cost legibility only; false negatives
-cost IRB compliance.
+match is replaced with ``<CATEGORY>`` (e.g. ``<EMAIL>``, ``<ANTHROPIC_KEY>``).
+Intentionally conservative — false positives here cost legibility only;
+false negatives cost IRB compliance OR API-key disclosure.
 """
 
 

--- a/tests/security/test_keystore.py
+++ b/tests/security/test_keystore.py
@@ -1,0 +1,129 @@
+"""KeyStore unit tests + parent-environ-leak regression.
+
+Two contracts to enforce:
+
+1. Keys live in process memory only — never in ``os.environ``.
+2. ``env_for_subprocess(...)`` returns a per-call dict suitable for
+   ``subprocess.run(env=...)`` without ever mutating the parent's env.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from scripts.ai_assistant.keystore import ENV_VAR_BY_PROVIDER, KeyStore
+
+# ── Direct KeyStore correctness ────────────────────────────────────────────
+
+
+def test_set_and_get_round_trip() -> None:
+    ks = KeyStore()
+    ks.set("anthropic", "sk-ant-test-key-1234")
+    assert ks.get("anthropic") == "sk-ant-test-key-1234"
+    assert ks.has("anthropic") is True
+
+
+def test_get_missing_returns_none() -> None:
+    ks = KeyStore()
+    assert ks.get("openai") is None
+    assert ks.has("openai") is False
+
+
+def test_clear_one_provider() -> None:
+    ks = KeyStore()
+    ks.set("anthropic", "k1")
+    ks.set("openai", "k2")
+    ks.clear("anthropic")
+    assert ks.has("anthropic") is False
+    assert ks.has("openai") is True
+
+
+def test_clear_all() -> None:
+    ks = KeyStore()
+    ks.set("anthropic", "k1")
+    ks.set("openai", "k2")
+    ks.clear()
+    assert ks.has("anthropic") is False
+    assert ks.has("openai") is False
+
+
+def test_set_normalises_provider_case() -> None:
+    """Case-insensitive provider lookup so ``Anthropic`` and ``anthropic``
+    resolve to the same slot — defends against UI inconsistencies."""
+    ks = KeyStore()
+    ks.set("Anthropic", "k1")
+    assert ks.get("anthropic") == "k1"
+    assert ks.get("ANTHROPIC") == "k1"
+
+
+def test_unknown_provider_set_raises() -> None:
+    """Only known providers (anthropic/openai/google/nvidia) are storable —
+    typos surface immediately, not at next API call."""
+    ks = KeyStore()
+    with pytest.raises(ValueError):
+        ks.set("totally-not-a-provider", "k1")
+
+
+def test_empty_key_raises() -> None:
+    ks = KeyStore()
+    with pytest.raises(ValueError):
+        ks.set("anthropic", "")
+
+
+# ── env_for_subprocess: never mutate parent env ─────────────────────────────
+
+
+def test_env_for_subprocess_returns_only_requested_providers() -> None:
+    ks = KeyStore()
+    ks.set("anthropic", "k1")
+    ks.set("openai", "k2")
+    env = ks.env_for_subprocess(["anthropic"])
+    assert env == {"ANTHROPIC_API_KEY": "k1"}
+
+
+def test_env_for_subprocess_skips_unset_providers() -> None:
+    ks = KeyStore()
+    ks.set("anthropic", "k1")
+    env = ks.env_for_subprocess(["anthropic", "openai"])
+    assert env == {"ANTHROPIC_API_KEY": "k1"}  # openai not set, skipped
+
+
+def test_env_for_subprocess_does_not_mutate_os_environ(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The single most important regression test: building a subprocess env
+    must NOT pollute the parent's ``os.environ``."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    ks = KeyStore()
+    ks.set("anthropic", "secret-key")
+    _ = ks.env_for_subprocess(["anthropic"])
+    assert "ANTHROPIC_API_KEY" not in os.environ
+
+
+def test_env_for_subprocess_unknown_provider_raises() -> None:
+    ks = KeyStore()
+    ks.set("anthropic", "k1")
+    with pytest.raises(ValueError):
+        ks.env_for_subprocess(["bogus"])
+
+
+# ── ENV_VAR_BY_PROVIDER mapping is the source of truth ─────────────────────
+
+
+def test_env_var_mapping_covers_supported_providers() -> None:
+    """The mapping must include every provider the wizard / cli let users
+    pick. Missing entries silently strand keys."""
+    expected = {"anthropic", "openai", "google", "nvidia"}
+    assert set(ENV_VAR_BY_PROVIDER) == expected
+
+
+def test_env_var_names_match_sdk_conventions() -> None:
+    """LangChain SDKs auto-pick keys from these specific env-var names; if
+    we drift from those, the explicit ``api_key=`` override in
+    ``agent_graph.py`` is the only thing keeping things working."""
+    assert ENV_VAR_BY_PROVIDER["anthropic"] == "ANTHROPIC_API_KEY"
+    assert ENV_VAR_BY_PROVIDER["openai"] == "OPENAI_API_KEY"
+    assert ENV_VAR_BY_PROVIDER["google"] == "GOOGLE_API_KEY"
+    assert ENV_VAR_BY_PROVIDER["nvidia"] == "NVIDIA_API_KEY"

--- a/tests/security/test_log_hygiene_keys.py
+++ b/tests/security/test_log_hygiene_keys.py
@@ -1,0 +1,118 @@
+"""API-key redaction patterns for ``scripts.utils.log_hygiene``.
+
+Companion to ``test_log_hygiene.py`` (which covers PHI patterns). After
+PR #3 the keystore keeps keys out of ``os.environ`` entirely, so keys
+never reach the logger via env-var dump. But defense in depth: if a key
+ever lands in a log message — through a stack trace, a tool call, or a
+copy-paste — the redactor must scrub it before the message is written
+to ``.logs/``.
+"""
+
+from __future__ import annotations
+
+from scripts.utils.log_hygiene import API_KEY_PATTERNS, PHIRedactingFilter, _redact
+
+# A 32-byte dummy key — these tests only exercise the API-key patterns,
+# never the subject-ID HMAC pass.
+_DUMMY_HMAC_KEY = b"\x00" * 32
+
+
+def _filter() -> PHIRedactingFilter:
+    return PHIRedactingFilter(hmac_key=_DUMMY_HMAC_KEY)
+
+
+# ── Provider-specific redaction ─────────────────────────────────────────────
+
+
+def test_redacts_anthropic_key() -> None:
+    raw = "auth failed for sk-ant-api03-A1b2C3d4E5f6G7h8I9j0K1L2M3N4O5P6Q7R8S9T0_USER123"
+    out = _redact(raw, _filter())
+    assert "sk-ant-api03" not in out
+    assert "<ANTHROPIC_KEY>" in out
+
+
+def test_redacts_openai_key() -> None:
+    raw = "request failed: sk-proj-A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0U1V2"
+    out = _redact(raw, _filter())
+    assert "sk-proj-A1B2" not in out
+    assert "<OPENAI_KEY>" in out
+
+
+def test_redacts_openai_key_no_proj_prefix() -> None:
+    raw = "Bearer sk-A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0"
+    out = _redact(raw, _filter())
+    assert "sk-A1B2C3D4" not in out
+    assert "<OPENAI_KEY>" in out
+
+
+def test_redacts_nvidia_key() -> None:
+    raw = "Authorization: Bearer nvapi-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+    out = _redact(raw, _filter())
+    assert "nvapi-aBcDeFgHi" not in out
+    assert "<NVIDIA_KEY>" in out
+
+
+def test_redacts_google_key() -> None:
+    raw = "Failed: AIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q"
+    out = _redact(raw, _filter())
+    assert "AIzaSyA1B2" not in out
+    assert "<GOOGLE_KEY>" in out
+
+
+# ── False-positive avoidance ────────────────────────────────────────────────
+
+
+def test_short_sk_prefix_not_redacted() -> None:
+    """A bare ``sk-`` reference without the full key length is NOT redacted —
+    short flags / config keys / docs must pass through unchanged."""
+    raw = "config field 'sk-flag' enabled"
+    out = _redact(raw, _filter())
+    assert "sk-flag" in out
+
+
+def test_short_aiza_prefix_not_redacted() -> None:
+    raw = "see helper AIzaShortName"  # too short for the AIza-key pattern
+    out = _redact(raw, _filter())
+    assert "AIzaShortName" in out
+
+
+def test_normal_text_unchanged() -> None:
+    raw = "Pipeline complete; 1234 records processed."
+    out = _redact(raw, _filter())
+    assert out == raw  # no false positives on plain prose
+
+
+# ── Multi-line / embedded contexts ──────────────────────────────────────────
+
+
+def test_redacts_key_in_stack_trace() -> None:
+    """A key embedded in a multi-line traceback should still be scrubbed."""
+    raw = (
+        "Traceback:\n"
+        '  File "x.py", line 1\n'
+        "    response = client.completions(api_key='sk-ant-api03-LONGKEYBODYABCDEFGHIJKLMNOPQRSTUVWXYZ_ABC')\n"
+        "AuthenticationError: bad key\n"
+    )
+    out = _redact(raw, _filter())
+    assert "sk-ant-api03-LONGKEYBODY" not in out
+    assert "<ANTHROPIC_KEY>" in out
+
+
+def test_redacts_multiple_keys_in_one_line() -> None:
+    raw = (
+        "primary=sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "
+        "fallback=sk-A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0"
+    )
+    out = _redact(raw, _filter())
+    assert "sk-ant-api03-AAAA" not in out
+    assert "sk-A1B2C3D4" not in out
+    assert out.count("<ANTHROPIC_KEY>") == 1
+    assert out.count("<OPENAI_KEY>") == 1
+
+
+# ── Pattern catalog completeness ────────────────────────────────────────────
+
+
+def test_pattern_catalog_covers_supported_providers() -> None:
+    labels = {label for label, _ in API_KEY_PATTERNS}
+    assert labels == {"ANTHROPIC_KEY", "OPENAI_KEY", "NVIDIA_KEY", "GOOGLE_KEY"}

--- a/tests/security/test_no_keys_in_parent_environ.py
+++ b/tests/security/test_no_keys_in_parent_environ.py
@@ -1,0 +1,74 @@
+"""Regression test: no key-handling code path may write to the parent's
+``os.environ``.
+
+This is the core integration check for PR #3. Even when the wizard's
+``apply_llm_config`` is called or ``agent_graph.build_chat_model`` is
+invoked, the parent process's ``os.environ`` for ``*_API_KEY`` vars must
+remain empty.
+
+Pre-existing keys (set by the user in their shell before launching the
+app) are NOT cleared by this test — that's a user choice and we read
+them once into the keystore on first launch. What we forbid is the app
+*writing* a key into the env where it didn't already exist.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_API_KEY_VARS = (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "NVIDIA_API_KEY",
+    "GEMINI_API_KEY",
+)
+
+
+@pytest.fixture()
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip any pre-existing API key env vars so we can detect new writes."""
+    for var in _API_KEY_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_keystore_set_does_not_touch_environ(clean_env: None) -> None:
+    """Storing a key via the KeyStore must NOT propagate to ``os.environ``."""
+    from scripts.ai_assistant.keystore import KeyStore
+
+    ks = KeyStore()
+    ks.set("anthropic", "sk-ant-test")
+    for var in _API_KEY_VARS:
+        assert var not in os.environ, f"{var} leaked into os.environ"
+
+
+def test_env_for_subprocess_returns_dict_without_mutating(clean_env: None) -> None:
+    """Building a subprocess env dict must NOT touch the parent env."""
+    from scripts.ai_assistant.keystore import KeyStore
+
+    ks = KeyStore()
+    ks.set("anthropic", "sk-ant-test")
+    ks.set("openai", "sk-test-openai")
+    env = ks.env_for_subprocess(["anthropic", "openai"])
+    assert "ANTHROPIC_API_KEY" in env
+    assert "OPENAI_API_KEY" in env
+    for var in _API_KEY_VARS:
+        assert var not in os.environ, f"{var} leaked during env_for_subprocess"
+
+
+def test_keystore_clear_does_not_touch_environ(
+    clean_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the user pre-set a key in their shell env, KeyStore.clear must
+    leave the shell env alone — it's the user's session, not ours to mutate."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "shell-set-by-user")
+    from scripts.ai_assistant.keystore import KeyStore
+
+    ks = KeyStore()
+    ks.set("anthropic", "different-key")
+    ks.clear("anthropic")
+    # The shell-set value is untouched.
+    assert os.environ.get("ANTHROPIC_API_KEY") == "shell-set-by-user"


### PR DESCRIPTION
## Summary

Closes the parent-process API-key leak left open by [PR #2](https://github.com/solomonsjoseph/RePORT-AI-Portal/pull/2). The sandbox child no longer sees ``ANTHROPIC_API_KEY`` (and friends) in its env after PR #2; this PR removes them from the **parent's** ``os.environ`` too.

After this PR:

- API keys live in an in-memory ``KeyStore`` (Streamlit session state, or a process global outside Streamlit).
- LangChain client constructors get the key explicitly via ``api_key=`` — no SDK auto-pickup from env.
- The pipeline subprocess that needs ``ANTHROPIC_API_KEY`` for vision-API calls receives it via a per-call ``env=`` injection — the parent's env stays clean before, during, and after.
- API keys leaked into log output are redacted by ``scripts.utils.log_hygiene`` (defense in depth — they shouldn't reach the logger at all now, but if a stack trace or copy-paste lets one through, the patterns catch it).

This is **PR #3 of 3** in the Phase 2 hardening track. PR #4 (adversarial ``phi_safe.guard_user_prompt`` tests) is the last gate before bumping to v0.17.0.

## Architecture

### New: ``scripts/ai_assistant/keystore.py`` (164 LoC)

```python
class KeyStore:
    set(provider, key) -> None
    get(provider) -> str | None
    has(provider) -> bool
    clear(provider | None) -> None
    env_for_subprocess(providers) -> dict[str, str]
```

The ``env_for_subprocess`` helper is the only place keys leave the store in env-shaped form, and it returns a *new* dict — never mutates ``os.environ``.

``provider_slug_for(langchain_provider)`` maps LangChain-style strings (``"google-genai"``, ``"nvidia-ai-endpoints"``) to KeyStore slugs (``"google"``, ``"nvidia"``) so the wizard / cli / agent_graph all map identically.

### Refactored call sites

| File | Change |
|---|---|
| ``scripts/ai_assistant/ui/wizard.py`` | ``apply_llm_config`` / ``ensure_llm_config`` route to ``keystore.set()``; ``run_pipeline`` uses ``env_for_subprocess`` for the pipeline call. |
| ``scripts/ai_assistant/cli.py`` | Same pattern: ``keystore.set()`` instead of ``os.environ[X] = key``. ""Key already set?"" check accepts EITHER KeyStore or a user-pre-exported shell env var. |
| ``scripts/ai_assistant/agent_graph.py`` | ``_build_llm`` reads from KeyStore and passes ``api_key=`` to both ``ChatNVIDIA(...)`` and ``init_chat_model(...)``. |

### Defense in depth: ``scripts/utils/log_hygiene.py``

Adds 4 new ``API_KEY_PATTERNS``:

```python
("ANTHROPIC_KEY", r"sk-ant-[A-Za-z]+\d*-[A-Za-z0-9_\-]{20,}")
("OPENAI_KEY",    r"sk-(?:proj-)?[A-Za-z0-9]{40,}")
("NVIDIA_KEY",    r"nvapi-[A-Za-z0-9_\-]{30,}")
("GOOGLE_KEY",    r"AIza[A-Za-z0-9_\-]{35}")
```

Each pattern requires the full provider-specific length so short references like ``sk-flag`` or ``AIzaShortName`` are NOT redacted. Applied first in ``_GENERIC_PATTERNS`` so a key embedded in a longer string is caught before any PHI heuristic might claim part of it.

## Tests (30 new, all passing)

- **``tests/security/test_keystore.py`` — 16 tests**: round-trip, case normalisation, unknown-provider rejection, ``env_for_subprocess`` does not mutate ``os.environ``, ENV_VAR_BY_PROVIDER mapping completeness.
- **``tests/security/test_log_hygiene_keys.py`` — 11 tests**: per-provider redaction, false-positive avoidance (short ``sk-`` and ``AIza`` refs pass through), multi-key lines, stack-trace embedding.
- **``tests/security/test_no_keys_in_parent_environ.py`` — 3 tests**: the integration regression that ``KeyStore.set/clear/env_for_subprocess`` never write to ``os.environ`` for any of the 5 LLM-key vars.

## Test plan

- [x] 30 new security tests pass
- [x] All 28 existing ``tests/test_agent_tools.py`` tests still pass
- [x] All 20 sandbox isolation tests still pass (17 macOS + 3 Linux-skip on dev; full 20 on Linux CI)
- [x] Full suite: 819 pass + 3 skip (macOS local)
- [x] Ruff strict, mypy, doc-freshness all green
- [ ] CI on Linux exercises the same — verify on this PR

## Out of scope (deferred to PR #4 / future)

- Adversarial prompt-injection tests for ``phi_safe.guard_user_prompt`` — that's PR #4.
- Encryption at rest for ``tmp/`` (Phase 3, not v0.17.0).
- Auth, multi-tenancy.
- Removing keys from ``st.session_state["api_key_saved"]`` after copying to KeyStore — kept for now so the password input retains its value across reruns.