### PR TITLE
chore: bump 0.16.1 → 0.17.0 (Phase 2 hardening complete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,10 +494,10 @@ uv run python main.py --version
 
 | Commit Message | Version Bump | Example |
 |----------------|--------------|---------|
-| `fix: ...` | **Patch** | 0.16.1 → 0.16.2 |
-| `feat: ...` | **Minor** | 0.16.1 → 0.17.0 |
-| `feat!: ...` or `BREAKING CHANGE:` | **Major** | 0.16.1 → 1.0.0 |
-| Other (docs, chore, refactor, style, test) | **No bump** | 0.16.1 (unchanged) |
+| `fix: ...` | **Patch** | 0.17.0 → 0.17.1 |
+| `feat: ...` | **Minor** | 0.17.0 → 0.18.0 |
+| `feat!: ...` or `BREAKING CHANGE:` | **Major** | 0.17.0 → 1.0.0 |
+| Other (docs, chore, refactor, style, test) | **No bump** | 0.17.0 (unchanged) |
 
 **Via Git hooks (automatic):** commit normally — the post-commit hook analyses
 the message and bumps the version automatically:
@@ -659,4 +659,4 @@ details.
 
 ---
 
-**Version**: 0.16.1 | **Status**: Beta (Active Development — Single-Study Mode)
+**Version**: 0.17.0 | **Status**: Beta (Active Development — Single-Study Mode)

--- a/__version__.py
+++ b/__version__.py
@@ -28,7 +28,7 @@ __all__ = ["__version__", "__version_info__"]
 # Semantic Versioning normal version: X.Y.Z with no leading zeroes except zero itself.
 _SEMVER_CORE_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
-__version__: str = "0.16.1"
+__version__: str = "0.17.0"
 """Canonical repository version in ``MAJOR.MINOR.PATCH`` form."""
 
 _match = _SEMVER_CORE_RE.fullmatch(__version__)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 app:
   name: RePORT AI Portal
-  version: "0.16.1"
+  version: "0.17.0"
   mode: user
   log_level: INFO
 

--- a/docs/sphinx/developer_guide/versioning.rst
+++ b/docs/sphinx/developer_guide/versioning.rst
@@ -15,7 +15,7 @@ The canonical version lives in ``__version__.py`` at the repository root:
 
 .. code-block:: python
 
-   __version__: str = "0.16.1"
+   __version__: str = "0.17.0"
 
 All other modules import from this single source:
 


### PR DESCRIPTION
## Summary

Bumps ``__version__`` to **0.17.0** — the milestone you set when we started this work session: ""Phase 2 hardening complete, ready to call it 0.17.0"".

What 0.17.0 represents (closed across PRs #1-4):

- **Subprocess-isolated LLM Python execution** with clean env (no ``*_API_KEY``), OS rlimits on Linux, AST guards inside the child as defense in depth.
- **Generated code is persisted** as runnable ``.py`` files with a replication header + a ``replicate.py`` CLI for users to re-run analyses on their own data.
- **API keys never enter ``os.environ``** in the parent process. They live in a session-scoped KeyStore and are passed explicitly to LangChain client constructors via ``api_key=``. The pipeline subprocess gets them only via a per-call ``env=`` injection scoped to that single subprocess.
- **Log redaction patterns** for Anthropic / OpenAI / NVIDIA / Google API key formats, in case a key ever lands in a log message via stack trace or copy-paste.
- **+56 new security tests** (sandbox isolation, KeyStore correctness, log redaction, adversarial prompt injection / PHI smuggling / key-disclosure chain). Total suite: 845 pass + 3 Linux-skip.

## Files changed

| File | Change |
|---|---|
| ``__version__.py`` | ``0.16.1`` → ``0.17.0`` |
| ``README.md`` | Status badge + bump-rules table example |
| ``docs/sphinx/developer_guide/versioning.rst`` | Canonical-version example |
| ``config/config.yaml`` | ``app.version`` |

## Test plan

- [x] ``lint_doc_freshness`` linter green at ``__version__=0.17.0``
- [x] Full suite: 845 pass + 3 Linux-skip
- [ ] CI green on this PR

## What is *not* in v0.17.0 (deferred to Phase 3)

- Encryption at rest for ``tmp/`` / ``.logs/``
- Multi-tenant auth, RBAC
- Docker / nsjail / seccomp profiles
- Trio JSONL → parquet conversion (sandbox load-time optimisation)
- Removing keys from ``st.session_state["api_key_saved"]`` after copying to KeyStore (kept for password-input UX)

These are real but separate scope; 0.17.0 is honest about closing only the threats the audit flagged as "must-fix before v1.0".