### PR TITLE
fix(deps): restore langchain meta-package — unbreaks live LLM flow (PR #6 regression)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,14 @@ ai_assistant = [
     # GHSA-fv5p-p927-qmxr (April 2026 audit). Pinning <2.0 within the 1.x
     # line so future minor bumps are auto-allowed while major API changes
     # still go through review.
+    # ``langchain`` (the meta-package) provides the ``langchain.chat_models``
+    # router used by ``scripts.ai_assistant.agent_graph._build_llm`` to
+    # instantiate any provider via ``init_chat_model``. Before PR #6 it
+    # was pulled in transitively via ``langchain-community``; that dep was
+    # removed in PR #6 and the live LLM flow broke (ModuleNotFoundError on
+    # ``from langchain.chat_models import init_chat_model``). Pinned
+    # explicitly here so the regression cannot recur.
+    "langchain>=1.0.0,<2.0.0",
     "langchain-core>=1.0.0,<2.0.0",
     # langchain-community removed — unused in our codebase, and its 1.x line
     # is still in alpha (pinning to 0.x would block langchain-core 1.x). If

--- a/tests/security/test_llm_construction_smoke.py
+++ b/tests/security/test_llm_construction_smoke.py
@@ -1,0 +1,104 @@
+"""End-to-end smoke tests: actually instantiate the chat-model objects.
+
+These tests are deliberately NOT mocked. The unit-test suite as it stood
+through PR #6 mocked every LangChain integration point, which let
+PR #6's removal of ``langchain-community`` ship green even though it
+broke the live ``from langchain.chat_models import init_chat_model``
+import the wizard's whole LLM flow depends on.
+
+This module validates the *real* object graph:
+
+1. ``langchain.chat_models.init_chat_model`` is importable. (The bug
+   PR #6 introduced was exactly this import returning
+   ``ModuleNotFoundError`` because the ``langchain`` meta-package was
+   no longer pulled in transitively.)
+2. ``scripts.ai_assistant.agent_graph._build_llm(provider, model)`` can
+   construct a chat-model object for every provider the wizard exposes,
+   using a fake key from the KeyStore.
+
+These tests use placeholder keys — no network calls are made; the
+constructors return without contacting the provider. If a future
+LangChain bump removes ``init_chat_model`` for real, this suite fails
+on every provider at once and the regression is impossible to miss.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_langchain_chat_models_init_chat_model_is_importable() -> None:
+    """Direct regression for the PR #6 breakage: ``from langchain.chat_models
+    import init_chat_model`` must succeed. If this import fails, every
+    non-Ollama LLM provider is broken."""
+    chat_models = importlib.import_module("langchain.chat_models")
+    assert hasattr(chat_models, "init_chat_model"), (
+        "init_chat_model missing — every provider in agent_graph._build_llm "
+        "will fail. Verify ``langchain`` is in pyproject.toml ai_assistant group."
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    [
+        ("anthropic", "claude-sonnet-4-6"),
+        ("openai", "gpt-4.1"),
+        ("google-genai", "gemini-2.5-flash"),
+    ],
+)
+def test_build_llm_constructs_chat_model_for_provider(
+    provider: str, model: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_build_llm`` must return a usable client object for every supported
+    provider. We use a placeholder key (no network call); the test only
+    proves construction succeeds — i.e. the import path, the api_key
+    routing, and the LangChain version are all consistent."""
+    # Strip any real shell-set keys so the test exercises the KeyStore path,
+    # not the SDK auto-pickup.
+    for var in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "NVIDIA_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    from scripts.ai_assistant.keystore import KeyStore, provider_slug_for
+
+    slug = provider_slug_for(provider)
+    assert slug is not None, f"provider_slug_for({provider!r}) returned None"
+
+    ks = KeyStore()
+    ks.set(slug, "sk-test-placeholder-not-a-real-key")
+
+    # Patch get_keystore() to return our test instance.
+    import scripts.ai_assistant.keystore as keystore_mod
+
+    monkeypatch.setattr(keystore_mod, "get_keystore", lambda: ks)
+
+    # Force re-import of agent_graph so it picks up the patched keystore
+    # accessor (it imports get_keystore at function-call time, so this is
+    # belt-and-braces).
+    from scripts.ai_assistant.agent_graph import _build_llm
+
+    client = _build_llm(provider, model)
+    assert client is not None
+    assert client.__class__.__name__.startswith("Chat"), (
+        f"expected a Chat* client, got {type(client).__name__}"
+    )
+
+
+def test_build_llm_for_ollama_works_without_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ollama is local — no API key needed; ``_build_llm`` should still
+    construct successfully (and not crash on the missing keystore entry)."""
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+    from scripts.ai_assistant.agent_graph import _build_llm
+
+    # Ollama returns ChatOllama; we only test construction, not connectivity.
+    client = _build_llm("ollama", "qwen3:8b")
+    assert client is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1436,6 +1436,20 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain"
+version = "1.2.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", size = 574732, upload-time = "2026-04-03T14:26:03.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", size = 112714, upload-time = "2026-04-03T14:26:02.557Z" },
+]
+
+[[package]]
 name = "langchain-anthropic"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3488,6 +3502,7 @@ dependencies = [
 [package.dev-dependencies]
 ai-assistant = [
     { name = "kaleido" },
+    { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
@@ -3550,6 +3565,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 ai-assistant = [
     { name = "kaleido", specifier = ">=1.0.0,<2.0" },
+    { name = "langchain", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=3.0.0,<4.0.0" },


### PR DESCRIPTION
## Summary

**Hot-fix for a v0.17.0 regression.** PR #6 broke the live LLM query flow even though all 845 tests passed. This PR restores it and adds the regression-test pack that should have existed before.

## What broke

[``scripts/ai_assistant/agent_graph.py:65``](scripts/ai_assistant/agent_graph.py#L65) imports::

    from langchain.chat_models import init_chat_model

Pre-PR-6, the ``langchain`` meta-package was pulled in transitively via ``langchain-community``. PR #6 dropped ``langchain-community`` (correctly — we never imported it directly). What I missed: ``langchain-community`` was the *only* path bringing in ``langchain``. Net result on main between PR #6 merge and now:

```
ModuleNotFoundError: No module named 'langchain'
```

…on **every** non-Ollama LLM call. The unit suite (845 pass) didn't catch it because every LangChain integration was mocked. The wizard's actual ""user types question → agent answers"" flow was dead.

## Why my PR #6 commit message was wrong

It claimed: *""init_chat_model — present in 1.x with same call signature""*. I never actually verified that. **Web check now confirms:** ``init_chat_model`` lives at ``langchain.chat_models.base`` in ``langchain==1.2.15`` and the kwargs are unchanged from 0.3.x — but ``langchain`` itself has to be in the deps for any of that to matter.

## Fix

1. ``pyproject.toml``: explicit ``langchain>=1.0.0,<2.0.0`` in the ``ai_assistant`` group, with a comment explaining why so it cannot be silently dropped again.
2. **5 new smoke tests** in ``tests/security/test_llm_construction_smoke.py`` — these are NOT mocked. They:
   - Verify ``langchain.chat_models.init_chat_model`` is importable.
   - Construct a real chat-model object for ``anthropic``, ``openai``, ``google-genai`` (with placeholder keys, no network call).
   - Construct ``ChatOllama`` without any key.

If a future LangChain bump removes ``init_chat_model`` for real, **this suite fails on every provider at once** — impossible to miss at PR time.

## Verification (real, not mocked)

```bash
uv run python -c "from langchain.chat_models import init_chat_model; print('OK')"
# → OK

ANTHROPIC_API_KEY=fake uv run python -c "
from scripts.ai_assistant.keystore import get_keystore
get_keystore().set('anthropic', 'fake')
from scripts.ai_assistant.agent_graph import _build_llm
m = _build_llm('anthropic', 'claude-sonnet-4-6')
print('SUCCESS:', type(m).__name__)
"
# → SUCCESS: ChatAnthropic
```

## Test plan

- [x] Live import succeeds
- [x] Live chat-model construction succeeds for every provider
- [x] Full suite: **850 pass + 3 Linux-skip** (was 845; +5 from new smoke file)
- [x] Ruff strict, mypy, doc-freshness all green
- [ ] Linux CI exercises the same — verify on this PR

## Process notes (durable rules added to my memory)

Two lessons from this incident, saved as durable feedback memories so I don't repeat them:

1. **Never break the existing working system.** Green tests ≠ working app. Either fix-as-you-go or amend the plan. If a refactor would break the live flow, surface it before shipping.
2. **Web-verify every external claim.** No more ""I remember X is in Y v1.x."" Either run a live import, fetch the docs, or read the changelog. Pair every dep upgrade with a real-instantiation smoke test.

## After this merges

- Tag **v0.17.1** on the merge commit (the v0.17.0 tag is technically broken and should be superseded by v0.17.1).
- Rerun ``pip-audit`` to confirm no new advisories appeared (none expected; only added one pre-existing transitive dep).