### PR TITLE
chore: bump 0.17.0 → 0.17.1 (LLM-flow hot-fix release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,10 +494,10 @@ uv run python main.py --version
 
 | Commit Message | Version Bump | Example |
 |----------------|--------------|---------|
-| `fix: ...` | **Patch** | 0.17.0 → 0.17.1 |
-| `feat: ...` | **Minor** | 0.17.0 → 0.18.0 |
-| `feat!: ...` or `BREAKING CHANGE:` | **Major** | 0.17.0 → 1.0.0 |
-| Other (docs, chore, refactor, style, test) | **No bump** | 0.17.0 (unchanged) |
+| `fix: ...` | **Patch** | 0.17.1 → 0.17.2 |
+| `feat: ...` | **Minor** | 0.17.1 → 0.18.0 |
+| `feat!: ...` or `BREAKING CHANGE:` | **Major** | 0.17.1 → 1.0.0 |
+| Other (docs, chore, refactor, style, test) | **No bump** | 0.17.1 (unchanged) |
 
 **Via Git hooks (automatic):** commit normally — the post-commit hook analyses
 the message and bumps the version automatically:
@@ -659,4 +659,4 @@ details.
 
 ---
 
-**Version**: 0.17.0 | **Status**: Beta (Active Development — Single-Study Mode)
+**Version**: 0.17.1 | **Status**: Beta (Active Development — Single-Study Mode)

--- a/__version__.py
+++ b/__version__.py
@@ -28,7 +28,7 @@ __all__ = ["__version__", "__version_info__"]
 # Semantic Versioning normal version: X.Y.Z with no leading zeroes except zero itself.
 _SEMVER_CORE_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
-__version__: str = "0.17.0"
+__version__: str = "0.17.1"
 """Canonical repository version in ``MAJOR.MINOR.PATCH`` form."""
 
 _match = _SEMVER_CORE_RE.fullmatch(__version__)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 app:
   name: RePORT AI Portal
-  version: "0.17.0"
+  version: "0.17.1"
   mode: user
   log_level: INFO
 

--- a/docs/sphinx/developer_guide/versioning.rst
+++ b/docs/sphinx/developer_guide/versioning.rst
@@ -15,7 +15,7 @@ The canonical version lives in ``__version__.py`` at the repository root:
 
 .. code-block:: python
 
-   __version__: str = "0.17.0"
+   __version__: str = "0.17.1"
 
 All other modules import from this single source:
 


### PR DESCRIPTION
## Summary

Tracks **PR #7** — the hot-fix that re-added the ``langchain`` meta-package to the deps after PR #6 silently dropped it (via the ``langchain-community`` removal) and broke every non-Ollama LLM provider with ``ModuleNotFoundError`` despite green CI.

This bumps the version literals only. After merge, I'll tag ``v0.17.1`` on the merge commit.

## What 0.17.1 ships (vs 0.17.0)

The only code change between v0.17.0 and v0.17.1 is PR #7:

- ``langchain>=1.0.0,<2.0.0`` pinned explicitly in ``pyproject.toml`` ``ai_assistant`` group (with a comment so it can't be silently dropped again).
- 5 real-instantiation smoke tests in ``tests/security/test_llm_construction_smoke.py`` (not mocked — they actually import + construct).

All security guarantees from 0.17.0 unchanged: subprocess sandbox, KeyStore, log redaction, adversarial test pack, all 5 pip-audit advisories patched.

## Files changed in this PR

- ``__version__.py``: ``0.17.0`` → ``0.17.1``
- ``README.md``: status badge + bump-rules table
- ``docs/sphinx/developer_guide/versioning.rst``: canonical-version example
- ``config/config.yaml``: ``app.version``

## Test plan

- [x] Doc-freshness linter green at ``__version__=0.17.1``
- [x] Full suite: **850 pass + 3 Linux-skip**
- [x] LLM construction smoke tests pass (the regression-catcher)
- [ ] CI green on this PR

## On the ``v0.17.0`` tag

The ``v0.17.0`` git tag remains in place for archaeology but **should not be treated as a release** — it points at the broken pre-hot-fix state. The ``v0.17.1`` tag I'll create after this PR merges is the actual shippable release. The GitHub Release page will be created at v0.17.1 only.