### PR TITLE
fix(security): Phase 2.x++ pipeline + PHI polish (N1, N2, N3, N5, N11, N12)

### DIFF
--- a/main.py
+++ b/main.py
@@ -282,7 +282,10 @@ def _publish_leg(staging_dir: Path, trio_dir: Path, leg_name: str) -> bool:
 
     trio_dir.parent.mkdir(parents=True, exist_ok=True)
     if trio_dir.exists():
-        shutil.rmtree(trio_dir)
+        # Use secure_remove_tree (zero-fill + symlink-aware via assert_write_zone)
+        # instead of plain shutil.rmtree so a republish doesn't leave PHI-adjacent
+        # forensic blocks recoverable from the disk.
+        secure_remove_tree(trio_dir)
 
     try:
         staging_dir.rename(trio_dir)
@@ -817,6 +820,13 @@ For detailed documentation, see the Sphinx docs or README.md
     # Propagation runs, otherwise prune_pdfs has nothing to prune and the
     # resulting trio_bundle/pdfs/ would still reference dataset-dropped vars.
     pdf_extractions_dir = Path(config.STAGING_PDFS_DIR)
+    # Defensive zone assertion: misconfigured ``STAGING_PDFS_DIR`` (e.g.,
+    # pointing into a third-party path) must be caught at the earliest
+    # possible moment, before any PDF write touches the disk. The publish-
+    # time assertion is a backstop, not the primary guard.
+    from scripts.security.secure_env import assert_write_zone
+
+    assert_write_zone(pdf_extractions_dir)
 
     if args.build_bundle or args.pipeline:
         pdf_source: str | None = args.pdf_source
@@ -1023,6 +1033,8 @@ For detailed documentation, see the Sphinx docs or README.md
     # single artifact an IRB/IEC reviewer inspects to verify the full
     # raw → scrub → publish chain without reading any row contents.
     def run_lineage() -> None:
+        import hashlib as _hashlib
+
         try:
             from scripts.security.phi_scrub import load_scrub_config
 
@@ -1030,6 +1042,14 @@ For detailed documentation, see the Sphinx docs or README.md
             posture = scrub_cfg.compliance_posture if scrub_cfg is not None else "disabled"
         except Exception:
             posture = "unknown"
+
+        # PHI key fingerprint — gives IRB reviewers a verifiable handle
+        # without exposing the key itself. SHA-256 of the raw HMAC key.
+        phi_key_fp: str | None = None
+        try:
+            phi_key_fp = _hashlib.sha256(_load_phi_key()).hexdigest()
+        except (PHIKeyMissingError, PHIKeyPermissionError, PHIScrubError):
+            phi_key_fp = None  # leave manifest free of the field
 
         audit_dir = Path(config.STUDY_AUDIT_DIR)
         audit_dir.mkdir(parents=True, exist_ok=True)
@@ -1047,6 +1067,7 @@ For detailed documentation, see the Sphinx docs or README.md
             pipeline_version=__version__,
             compliance_posture=posture,
             manifest_path=audit_dir / "lineage_manifest.json",
+            phi_key_fingerprint=phi_key_fp,
         )
 
     run_step("Step 4: Emit Lineage Manifest", run_lineage)

--- a/scripts/ai_assistant/sandbox/runner.py
+++ b/scripts/ai_assistant/sandbox/runner.py
@@ -251,7 +251,13 @@ def _emit_manifest(
         "code_paths": code_paths or [],
         "truncated": truncated,
     }
-    (output_dir / "_sandbox_result.json").write_text(json.dumps(manifest), encoding="utf-8")
+    manifest_path = output_dir / "_sandbox_result.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    # The manifest carries figure / code paths and exit-status flags. PR #10
+    # chmod'd the saved .py files but missed this manifest — closing that
+    # gap so the manifest is owner-only too.
+    with contextlib.suppress(OSError):
+        manifest_path.chmod(0o600)
 
 
 def main(spec_path: str) -> int:

--- a/scripts/security/phi_scrub.py
+++ b/scripts/security/phi_scrub.py
@@ -1128,8 +1128,27 @@ def run_scrub(study_name: str | None = None) -> None:
 
     cfg = load_scrub_config()
     if cfg is None:
-        logger.info(
-            "phi_scrub: config not found at %s — no-op for this study",
+        # Missing scrub config = no rule application = raw PHI flows to
+        # ``trio_bundle/``. That is unsafe for any production run; require
+        # an explicit opt-in env var to acknowledge the risk in dev/test.
+        allow_disabled = os.environ.get("REPORTALIN_ALLOW_DISABLED_SCRUB", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        if not allow_disabled:
+            raise PHIScrubError(
+                "phi_scrub: config not found at "
+                f"{config.PHI_SCRUB_CONFIG_PATH}. Refusing to publish a trio "
+                "bundle without rule application — raw PHI would flow through "
+                "unredacted. Either provision the YAML or set "
+                "``REPORTALIN_ALLOW_DISABLED_SCRUB=1`` to acknowledge the risk "
+                "(dev / test only)."
+            )
+        logger.warning(
+            "phi_scrub: config not found at %s — running in DISABLED mode "
+            "(REPORTALIN_ALLOW_DISABLED_SCRUB=1). Raw PHI may flow through.",
             config.PHI_SCRUB_CONFIG_PATH,
         )
         _emit_audit(

--- a/scripts/security/phi_scrub.yaml
+++ b/scripts/security/phi_scrub.yaml
@@ -210,6 +210,11 @@ id_fields:
   - {pattern: "^SUBJID$", label: "SUBJ"}
   - {pattern: "^NC_SUBJID$", label: "SUBJ"}
   - {pattern: "(?:patient|subject|participant)[-_]?(?:id|num|no)", label: "SUBJ"}
+  # ── Screening / enrolment numbers (Indo-VAP and similar TB studies) ───────
+  # Index Case (IC_*) and Index Subject (IS_*) screen numbers are linkable
+  # back to enrolment registers; pseudonymise rather than let them flow raw.
+  - {pattern: "^I[CS]_SCRNNUM$", label: "SCRN"}
+  - {pattern: "(?:scrn|screen|enrol(?:l)?)num", label: "SCRN"}
   # ── Family / household IDs ────────────────────────────────────────────────
   - {pattern: "^FID$", label: "FAM"}
   - {pattern: "^FID\\d+$", label: "FAM"}

--- a/scripts/utils/lineage.py
+++ b/scripts/utils/lineage.py
@@ -120,6 +120,7 @@ def emit_lineage_manifest(
     pipeline_version: str,
     compliance_posture: str,
     manifest_path: Path,
+    phi_key_fingerprint: str | None = None,
 ) -> dict[str, Any]:
     """Assemble + atomically write the lineage manifest for this run.
 
@@ -171,6 +172,12 @@ def emit_lineage_manifest(
         "outputs": outputs,
         "steps": steps,
     }
+    # The PHI key fingerprint (SHA-256 of the HMAC key bytes) lets an IRB
+    # reviewer verify that the pseudonyms in trio_bundle/ were generated
+    # with the claimed key — without exposing the key itself. Optional so
+    # legacy callers without a key still emit a valid manifest.
+    if phi_key_fingerprint is not None:
+        manifest["phi_key_fingerprint"] = phi_key_fingerprint
 
     atomic_write_json(manifest_path, manifest)
     logger.info(

--- a/tests/security/test_phase2_pipeline_polish.py
+++ b/tests/security/test_phase2_pipeline_polish.py
@@ -1,0 +1,145 @@
+"""Phase 2.x++ pipeline polish — regression tests for v0.17.2 follow-up fixes.
+
+Companion to ``docs/irb_dossier/phase3_phi_followups.md``. Pins the
+follow-up items surfaced by the deeper extraction-pipeline + PHI-scrub-
+internals + PR-#10-re-verify audit on 2026-04-27:
+
+- **N1**  ``run_scrub`` fails closed when ``phi_scrub.yaml`` is absent
+- **N2**  ``_publish_leg`` uses ``secure_remove_tree`` (not plain rmtree)
+        for the old trio_bundle
+- **N3**  Lineage manifest carries ``phi_key_fingerprint``
+- **N5**  PDF staging destination zone-asserted at the inlet
+- **N11** Indo-VAP screen numbers (``IS_SCRNNUM`` / ``IC_SCRNNUM``) covered
+        by the pseudonymization id_fields rule set
+- **N12** Sandbox ``_sandbox_result.json`` manifest chmod'd 0o600
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+WINDOWS_SKIP = pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes only")
+
+
+# ── N12 — sandbox manifest chmod ────────────────────────────────────────────
+
+
+def test_sandbox_runner_chmods_sandbox_result_manifest() -> None:
+    """The ``_sandbox_result.json`` manifest at the end of a sandbox run
+    must be chmod'd 0o600 — PR #10 fixed the saved .py files but missed
+    the manifest. This pins it."""
+    src = Path("scripts/ai_assistant/sandbox/runner.py").read_text(encoding="utf-8")
+    assert "manifest_path.chmod(0o600)" in src or (
+        "manifest_path = output_dir" in src and "chmod(0o600)" in src
+    ), (
+        "_sandbox_result.json must be chmod'd 0o600 in _emit_manifest "
+        "(see runner.py:_emit_manifest)"
+    )
+
+
+# ── N5 — PDF staging zone assertion ─────────────────────────────────────────
+
+
+def test_main_zone_asserts_pdf_staging_destination() -> None:
+    """``main.py`` must call ``assert_write_zone(pdf_extractions_dir)`` at
+    the inlet, not just at publish time. Catches a misconfigured
+    ``STAGING_PDFS_DIR`` before any PDF write touches disk."""
+    src = Path("main.py").read_text(encoding="utf-8")
+    # Find the line where pdf_extractions_dir is assigned, then look for an
+    # assert_write_zone within the next 8 lines.
+    lines = src.splitlines()
+    for i, line in enumerate(lines):
+        if "pdf_extractions_dir = Path(config.STAGING_PDFS_DIR)" in line:
+            window = "\n".join(lines[i : i + 8])
+            assert "assert_write_zone(pdf_extractions_dir)" in window, (
+                "main.py must call assert_write_zone(pdf_extractions_dir) "
+                "immediately after resolving STAGING_PDFS_DIR"
+            )
+            return
+    pytest.fail("Could not locate pdf_extractions_dir assignment in main.py")
+
+
+# ── N2 — secure-remove old trio_bundle on republish ─────────────────────────
+
+
+def test_publish_leg_uses_secure_remove_tree_for_old_bundle() -> None:
+    """``_publish_leg`` must call ``secure_remove_tree`` (zero-fill +
+    zone-asserted) — not ``shutil.rmtree`` — when republishing over an
+    existing trio_bundle, so a re-run doesn't leave PHI-adjacent forensic
+    blocks on disk."""
+    # Line-window scan: find ``def _publish_leg`` and look at the next ~40
+    # lines. Avoids catastrophic regex backtracking on the 1000+ line file.
+    lines = Path("main.py").read_text(encoding="utf-8").splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if line.startswith("def _publish_leg(")),
+        None,
+    )
+    assert start is not None, "_publish_leg definition not found in main.py"
+    body = "\n".join(lines[start : start + 50])
+    assert "if trio_dir.exists():" in body, "trio_dir.exists() block not found"
+    assert "secure_remove_tree(trio_dir)" in body, (
+        "secure_remove_tree(trio_dir) must replace shutil.rmtree(trio_dir) "
+        "inside the trio_dir.exists() branch of _publish_leg"
+    )
+
+
+# ── N3 — phi_key_fingerprint in lineage manifest ────────────────────────────
+
+
+# NOTE: a live ``emit_lineage_manifest`` test would require monkey-patching
+# the ``secure_env`` zone marker which is frozen at import. The two static
+# checks below verify the same contract via source inspection — sufficient
+# for the regression-pin and avoids the import-time-fixture hang risk.
+
+
+def test_lineage_manifest_omits_fingerprint_when_not_provided() -> None:
+    """The fingerprint is optional — manifests without it must still be
+    valid (legacy callers). Verifies the new field is keyed-out cleanly."""
+    src = Path("scripts/utils/lineage.py").read_text(encoding="utf-8")
+    assert "phi_key_fingerprint: str | None = None" in src, (
+        "phi_key_fingerprint must be optional in the function signature"
+    )
+    assert "if phi_key_fingerprint is not None:" in src, (
+        "Manifest must omit the field when None (don't carry a null)"
+    )
+
+
+def test_main_emits_phi_key_fingerprint_to_lineage() -> None:
+    """``main.py``'s ``run_lineage`` must compute SHA-256 of the PHI key
+    and pass it to ``emit_lineage_manifest``."""
+    src = Path("main.py").read_text(encoding="utf-8")
+    assert "phi_key_fingerprint=phi_key_fp" in src, (
+        "main.py must pass the fingerprint into emit_lineage_manifest"
+    )
+    assert "_hashlib.sha256(_load_phi_key()).hexdigest()" in src, (
+        "main.py must compute the fingerprint as SHA-256 of the loaded key"
+    )
+
+
+# ── N11 — Indo-VAP screen numbers covered by pseudonymization ───────────────
+
+
+def test_phi_scrub_yaml_pseudonymises_indovap_screen_numbers() -> None:
+    """``IS_SCRNNUM`` and ``IC_SCRNNUM`` (Indo-VAP screen numbers — linkable
+    back to enrolment registers) must be matched by an ``id_fields`` rule
+    so they get HMAC-pseudonymised, not pass through raw."""
+    yaml_text = Path("scripts/security/phi_scrub.yaml").read_text(encoding="utf-8")
+    # The pattern we added handles both via ``^I[CS]_SCRNNUM$``.
+    assert "I[CS]_SCRNNUM" in yaml_text or "IS_SCRNNUM" in yaml_text, (
+        "phi_scrub.yaml id_fields must cover IS_SCRNNUM / IC_SCRNNUM"
+    )
+    # Behavioral round-trip: load the config, walk the id_fields, and
+    # confirm at least one pattern actually matches.
+    from scripts.security.phi_scrub import load_scrub_config
+
+    cfg = load_scrub_config()
+    assert cfg is not None, "phi_scrub.yaml failed to load"
+    matched = any(rule.pattern.match("IS_SCRNNUM") for rule in cfg.id_patterns)
+    assert matched, (
+        "No id_patterns rule actually matches the literal column 'IS_SCRNNUM'"
+    )
+    matched_ic = any(rule.pattern.match("IC_SCRNNUM") for rule in cfg.id_patterns)
+    assert matched_ic, "No id_patterns rule matches 'IC_SCRNNUM'"

--- a/tests/test_phi_scrub.py
+++ b/tests/test_phi_scrub.py
@@ -320,8 +320,13 @@ class TestRunScrub:
         monkeypatch_config: Path,
         sidecar_key: Path,
         scrub_config_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # no config file at scrub_config_path → module no-ops
+        # no config file at scrub_config_path → module no-ops, but ONLY when
+        # the explicit env override is set. Without the override, run_scrub
+        # raises (closes the silent-disabled-scrub gap).
+        monkeypatch.setenv("REPORTALIN_ALLOW_DISABLED_SCRUB", "1")
+
         rows = [{"SUBJID": "S1", "VISDAT": "2014-07-15"}]
         src = _seed_staging(monkeypatch_config, rows)
         phi_scrub.run_scrub(study_name="TEST")
@@ -333,6 +338,22 @@ class TestRunScrub:
         # Row is unchanged
         loaded = [json.loads(line) for line in src.read_text().splitlines() if line]
         assert loaded == rows
+
+    def test_no_config_without_override_raises_phi_scrub_error(
+        self,
+        monkeypatch_config: Path,
+        sidecar_key: Path,
+        scrub_config_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The default behavior is fail-closed: missing yaml + no env override
+        raises ``PHIScrubError`` so a misconfigured production run cannot
+        silently publish raw PHI."""
+        monkeypatch.delenv("REPORTALIN_ALLOW_DISABLED_SCRUB", raising=False)
+        rows = [{"SUBJID": "S1", "VISDAT": "2014-07-15"}]
+        _seed_staging(monkeypatch_config, rows)
+        with pytest.raises(phi_scrub.PHIScrubError, match="config not found"):
+            phi_scrub.run_scrub(study_name="TEST")
 
     def test_safe_harbor_drops_birthdate(
         self,


### PR DESCRIPTION
## Summary

Honest answer to *""is that all you could find on PHI handling?""* — **no**. A third-pass audit (extraction pipeline + PHI scrub internals + PR #10 re-verify) surfaced **12 NEW findings** including **1 bug I missed in my own PR #10**.

This PR closes the **6 small ones**. Architectural items (parallel-run lock, atomic publish, mandatory k-anon, l-diversity, PDF redaction, traceback sanitiser) remain Phase 3.

## Closes 6 of 12 findings

| # | Finding | Severity |
|---|---|---|
| **N1** | ``run_scrub`` silently disabled when ``phi_scrub.yaml`` absent — published raw PHI! Now fails closed; ``REPORTALIN_ALLOW_DISABLED_SCRUB=1`` env override for dev/test. | MEDIUM |
| **N2** | ``_publish_leg`` used plain ``shutil.rmtree`` for old trio_bundle. Now ``secure_remove_tree`` (zero-fill + zone-asserted). Closes forensic-recovery vector. | MEDIUM |
| **N3** | Lineage manifest now carries ``phi_key_fingerprint`` (SHA-256 of HMAC key) — IRB reviewer can verify pseudonyms came from the claimed key. | MEDIUM |
| **N5** | ``main.py`` zone-asserts ``pdf_extractions_dir`` at the inlet (was: only at publish time). Catches misconfigured staging before any PDF write. | MEDIUM |
| **N11** | Indo-VAP-specific ``IS_SCRNNUM``/``IC_SCRNNUM`` screen numbers now covered by ``id_fields`` rule. Were passing through raw. | MEDIUM (Indo-VAP) |
| **N12** | ``_sandbox_result.json`` manifest now chmod'd 0o600. **PR #10 missed this** — fixed the .py files but not the manifest. | MEDIUM |

## Bug I missed in PR #10 (N12)

The re-verify pass caught it: my P1d closed the sandbox `.py` files + `code/` dir but missed `_sandbox_result.json`. Fixed here. The lesson: *every* sandbox-written file needs a chmod follow-up, not just the obvious ones. Test added.

## Test plan

``tests/security/test_phase2_pipeline_polish.py`` — 6 regression tests + 1 new test in ``tests/test_phi_scrub.py``:

- [x] **N1**: 2 tests — fail-closed default + dev override path
- [x] **N2**: line-window source check (`secure_remove_tree(trio_dir)` in `_publish_leg`)
- [x] **N3**: 2 tests — optional-arg signature + `main.py` plumbing
- [x] **N5**: source check (`assert_write_zone(pdf_extractions_dir)` in `main.py` near config resolution)
- [x] **N11**: behavioral round-trip — load YAML, walk `id_patterns`, confirm `IS_SCRNNUM`/`IC_SCRNNUM` match
- [x] **N12**: source check (`manifest_path.chmod(0o600)` in `_emit_manifest`)

## Verification (per the no-breakage rule)

- Ruff strict ✓
- Doc-freshness linter ✓
- Full suite: **868 pass + 3 Linux-skip** (was 861)
- Live LLM smoke: ``ChatAnthropic`` instantiates end-to-end ✓

## NOT in this PR (deferred to Phase 3)

- **N4** Parallel ``main.py`` execution race — needs file-locking design
- **N6** Atomic publish copytree fallback — needs proper atomic-write pattern
- **N7-N10** Doc/tidy items
- All architectural items already in PR #9 docs (3.A k-anon, 3.B l-diversity, 3.F-H PDF redaction, 3.I traceback sanitiser, etc.)

## Audit lineage

User question: *""Was all change well researched and applied? Did it also cover extraction and pipeline?""*

Honest answers:

- **Mostly well-researched** (10/11 PR #10 items verified correct on re-check) — but I missed the manifest chmod. Test added so it can't regress.
- **No, didn't fully cover extraction pipeline** until this third audit pass. The new findings concentrate there (publish, scrub config gating, lineage, zone assertions). The two prior audits focused on agent boundary + sandbox + vision API.

After this merges, a separate small doc-only PR will update ``docs/irb_dossier/phase3_phi_followups.md`` to reflect the 6 closures + 6 deferred items.