### PR TITLE
feat(security): Phase 3.A + 3.B — mandatory k-anon + l-diversity on row-returning tools

### DIFF
--- a/scripts/ai_assistant/agent_tools.py
+++ b/scripts/ai_assistant/agent_tools.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -85,6 +85,47 @@ _INTERNAL_COLUMNS = frozenset(
         "_ingestion_ts",
     }
 )
+
+
+# Conservative default quasi-identifier columns for Indo-VAP. The k-anon
+# gate uses any of these that are actually present in the query result;
+# missing columns are silently skipped (no false-positive blocking on
+# datasets that don't carry that QI). Phase 4 will elevate this to a
+# per-dataset entry in the data dictionary.
+_DEFAULT_QUASI_IDENTIFIERS: tuple[str, ...] = (
+    "AGE",
+    "AGEY",
+    "AGEM",
+    "SEX",
+    "IS_SEX",
+    "IC_SEX",
+    "HHC_SEX",
+    "HC_SEX",
+    "DISTRICT",
+    "DIST",
+    "IS_DIST",
+    "IC_DIST",
+)
+
+# Conservative default sensitive attributes for l-diversity. Outcome /
+# diagnosis columns whose value (e.g., "DIED", "TB+") could re-identify
+# a small homogeneous equivalence class.
+_DEFAULT_SENSITIVE_ATTRIBUTES: tuple[str, ...] = (
+    "EE_DIED",
+    "EE_DIEDTB",
+    "TB_DX",
+    "TBSTATUS",
+    "OUTCOME",
+    "DEATHCAUSE",
+)
+
+
+def _present_columns(rows: list[dict[str, Any]], candidates: tuple[str, ...]) -> tuple[str, ...]:
+    """Return the subset of *candidates* that actually appears in any row."""
+    seen: set[str] = set()
+    for row in rows[:50]:  # sample is enough; column set is stable across rows
+        seen.update(row.keys())
+    return tuple(c for c in candidates if c in seen)
 
 
 def _read_jsonl(path: Path, *, max_records: int = 0) -> list[dict[str, Any]]:
@@ -486,14 +527,55 @@ def query_dataset(
         else:
             results.append({k: v for k, v in rec.items() if k not in _INTERNAL_COLUMNS})
 
+    # k-anonymity + l-diversity gate (Phase 3.A + 3.B). Run on the
+    # projected ``results`` (post-column-filter, post-row-filter) using
+    # whichever default QI / sensitive columns are present. If blocked,
+    # surface aggregate-only metadata + a clear refusal so the LLM can
+    # respond with bands rather than rows.
+    from scripts.ai_assistant.phi_safe import guard_rows_with_kanon_and_ldiv
+
+    qi_present = _present_columns(results, _DEFAULT_QUASI_IDENTIFIERS)
+    sens_present = _present_columns(results, _DEFAULT_SENSITIVE_ATTRIBUTES)
+
+    safe_records: list[Mapping[str, Any]] = list(results)
+    kanon_violation: dict[str, Any] | None = None
+
+    if qi_present and results:
+        gated, kanon_res, ldiv_res = guard_rows_with_kanon_and_ldiv(
+            results,
+            quasi_identifiers=qi_present,
+            sensitive_attributes=sens_present or None,
+            tool_name="query_dataset",
+        )
+        if kanon_res.blocked or (ldiv_res is not None and ldiv_res.blocked):
+            safe_records = []
+            kanon_violation = {
+                "gate": "kanon" if kanon_res.blocked else "l_diversity",
+                "k": 5,
+                "l": 2 if ldiv_res is not None else None,
+                "smallest_class_size": kanon_res.smallest_class_size,
+                "smallest_diversity": ldiv_res.smallest_diversity if ldiv_res else None,
+                "quasi_identifiers": list(qi_present),
+                "sensitive_attributes": list(sens_present),
+                "message": (
+                    "Row-level surface suppressed: an equivalence class of size "
+                    f"{kanon_res.smallest_class_size} would be re-identifiable. "
+                    "Re-query with broader bins (age band / district) or aggregate "
+                    "via get_dataset_stats / cross_reference_variables."
+                ),
+            }
+        else:
+            safe_records = list(gated)
+
     return json.dumps(
         {
             "dataset": matched_file.stem,
             "total_records": real_total,
             "rows_matching_filter": len(filtered) if filter_column else real_total,
-            "returned": len(results),
+            "returned": len(safe_records),
             "available_columns": all_columns,
-            "records": results,
+            "records": safe_records,
+            "kanon_violation": kanon_violation,
         },
         indent=2,
         ensure_ascii=False,
@@ -921,13 +1003,29 @@ def cross_reference_variables(variable_name: str) -> str:
             except OSError:
                 continue
 
+            # Apply small-cell suppression (Phase 3.A) so a population /
+            # completeness pair smaller than k=5 is not surfaced as an
+            # exact count — it becomes the suppressed label "<5". The
+            # completeness percentage is recomputed against the masked
+            # numerator so it doesn't reveal the suppressed count via
+            # arithmetic.
+            from scripts.security.kanon_gate import mask_small_cell
+
+            populated_safe = mask_small_cell(populated, k=5)
+            total_safe = mask_small_cell(total, k=5)
+            completeness_pct: Any
+            if isinstance(populated_safe, int) and isinstance(total_safe, int) and total_safe:
+                completeness_pct = round(populated_safe / total_safe * 100, 1)
+            else:
+                completeness_pct = "<5"
+
             dataset_presence.append(
                 {
                     "dataset": f.stem,
                     "matching_columns": matching_cols,
-                    "total_records": total,
-                    "populated_records": populated,
-                    "completeness_pct": round(populated / total * 100, 1) if total else 0.0,
+                    "total_records": total_safe,
+                    "populated_records": populated_safe,
+                    "completeness_pct": completeness_pct,
                 }
             )
 

--- a/scripts/ai_assistant/phi_safe.py
+++ b/scripts/ai_assistant/phi_safe.py
@@ -39,7 +39,12 @@ from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar, cast
 
-from scripts.security.kanon_gate import KAnonResult, kanon_check
+from scripts.security.kanon_gate import (
+    KAnonResult,
+    LDiversityResult,
+    kanon_check,
+    l_diversity_check,
+)
 from scripts.security.phi_gate import PHIGateResult, phi_gate_check
 
 logger = logging.getLogger(__name__)
@@ -48,6 +53,7 @@ __all__ = [
     "PHISafetyError",
     "UserPromptGuardResult",
     "guard_rows_with_kanon",
+    "guard_rows_with_kanon_and_ldiv",
     "guard_text",
     "guard_user_prompt",
     "phi_safe_return",
@@ -156,6 +162,63 @@ def guard_rows_with_kanon(
         )
         return [], result
     return rows_list, result
+
+
+def guard_rows_with_kanon_and_ldiv(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    quasi_identifiers: tuple[str, ...],
+    sensitive_attributes: tuple[str, ...] | None = None,
+    k: int = 5,
+    l_threshold: int = 2,
+    tool_name: str = "<unknown>",
+) -> tuple[
+    list[Mapping[str, Any]],
+    KAnonResult,
+    LDiversityResult | None,
+]:
+    """Run k-anonymity then (when ``sensitive_attributes`` is provided)
+    l-diversity. Returns ``(rows_to_surface, kanon_result, ldiv_result)``.
+
+    Either gate blocking sets ``rows_to_surface`` to an empty list. When
+    ``sensitive_attributes`` is ``None``, l-diversity is skipped and the
+    third return value is ``None`` — equivalent to the legacy
+    :func:`guard_rows_with_kanon` semantics with a richer return shape.
+
+    Phase 3.A + 3.B: this is the gate every row-returning tool should
+    call before serialising rows to the LLM. See
+    ``docs/irb_dossier/phase3_phi_followups.md``.
+    """
+    rows_list = list(rows)
+    kanon_res = kanon_check(rows_list, quasi_identifiers=quasi_identifiers, k=k)
+    if kanon_res.blocked:
+        logger.warning(
+            "phi_safe: tool %s k-anon blocked — smallest class %d < k=%d",
+            tool_name,
+            kanon_res.smallest_class_size,
+            k,
+        )
+        return [], kanon_res, None
+
+    ldiv_res: LDiversityResult | None = None
+    if sensitive_attributes:
+        ldiv_res = l_diversity_check(
+            rows_list,
+            quasi_identifiers=quasi_identifiers,
+            sensitive_attributes=sensitive_attributes,
+            l_threshold=l_threshold,
+        )
+        if ldiv_res.blocked:
+            logger.warning(
+                "phi_safe: tool %s l-diversity blocked — smallest "
+                "diversity %d < l=%d",
+                tool_name,
+                ldiv_res.smallest_diversity,
+                l_threshold,
+            )
+            return [], kanon_res, ldiv_res
+
+    return rows_list, kanon_res, ldiv_res
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/security/kanon_gate.py
+++ b/scripts/security/kanon_gate.py
@@ -33,7 +33,9 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "KAnonResult",
+    "LDiversityResult",
     "kanon_check",
+    "l_diversity_check",
     "mask_small_cell",
     "suppress_small_cells",
 ]
@@ -104,6 +106,88 @@ def kanon_check(
         blocked=blocked,
         smallest_class_size=smallest,
         violating_keys=tuple(violating),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class LDiversityResult:
+    """Outcome of an l-diversity check.
+
+    A row set passes l-diversity (l ≥ 2) when every equivalence class
+    (defined by the quasi-identifier tuple) contains at least *l*
+    distinct values for each sensitive attribute. l = 2 is the
+    smallest meaningful threshold; higher values resist homogeneity
+    attacks more strongly.
+
+    ``blocked`` is ``True`` when at least one (class, sensitive_attr)
+    pair has fewer than *l* distinct values. ``violating_classes``
+    enumerates which equivalence classes failed and on which attribute.
+    """
+
+    blocked: bool
+    smallest_diversity: int
+    violating_classes: tuple[tuple[str, str], ...]
+    """Tuples of ``(equivalence_class_key, sensitive_attribute_name)``
+    whose distinct-value count fell below *l*."""
+
+
+def l_diversity_check(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    quasi_identifiers: tuple[str, ...],
+    sensitive_attributes: tuple[str, ...],
+    l_threshold: int = 2,
+) -> LDiversityResult:
+    """Verify that every equivalence class has ≥ ``l_threshold`` distinct
+    values for every sensitive attribute.
+
+    Use AFTER :func:`kanon_check` — k-anonymity ensures classes are
+    large enough; l-diversity ensures they aren't homogeneous on the
+    outcomes that matter (e.g., all 5+ subjects in a class share
+    ``outcome=DIED``). Empty input returns ``blocked=False``.
+
+    Raises ``ValueError`` if either tuple is empty or ``l_threshold < 1``.
+    """
+    if l_threshold < 1:
+        raise ValueError(f"l_threshold must be >= 1, got {l_threshold}")
+    if not quasi_identifiers:
+        raise ValueError("quasi_identifiers must be non-empty")
+    if not sensitive_attributes:
+        raise ValueError("sensitive_attributes must be non-empty")
+
+    classes: dict[tuple[Any, ...], dict[str, set[Any]]] = {}
+    for row in rows:
+        key = tuple(row.get(col) for col in quasi_identifiers)
+        bucket = classes.setdefault(key, {attr: set() for attr in sensitive_attributes})
+        for attr in sensitive_attributes:
+            bucket[attr].add(row.get(attr))
+
+    if not classes:
+        return LDiversityResult(blocked=False, smallest_diversity=0, violating_classes=())
+
+    smallest = l_threshold
+    violations: list[tuple[str, str]] = []
+    for key, bucket in classes.items():
+        for attr, values in bucket.items():
+            div = len(values)
+            if div < smallest:
+                smallest = div
+            if div < l_threshold:
+                violations.append((_key_to_str(key), attr))
+
+    blocked = bool(violations)
+    if blocked:
+        logger.warning(
+            "l_diversity_check: smallest diversity %d < l=%d (%d violating "
+            "(class, attribute) pairs)",
+            smallest,
+            l_threshold,
+            len(violations),
+        )
+    return LDiversityResult(
+        blocked=blocked,
+        smallest_diversity=smallest,
+        violating_classes=tuple(sorted(violations)),
     )
 
 

--- a/tests/security/test_kanon_l_diversity.py
+++ b/tests/security/test_kanon_l_diversity.py
@@ -1,0 +1,250 @@
+"""Phase 3.A + 3.B regression tests — k-anonymity + l-diversity gates.
+
+Pins three contracts:
+
+1. ``l_diversity_check`` blocks when any equivalence class shares the
+   same value for a sensitive attribute across ≥ k members (homogeneity
+   attack against a k-anonymous release).
+2. ``guard_rows_with_kanon_and_ldiv`` runs k-anon then l-diversity in
+   sequence, blocking on either gate.
+3. ``query_dataset`` actually invokes the gate before serializing rows
+   (regression for the 2026-04-27 audit finding that the helper
+   existed but no production tool called it).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.ai_assistant.phi_safe import guard_rows_with_kanon_and_ldiv
+from scripts.security.kanon_gate import (
+    l_diversity_check,
+)
+
+# ── l_diversity_check ───────────────────────────────────────────────────────
+
+
+def test_l_diversity_passes_when_classes_are_diverse() -> None:
+    """5 rows in one class, 2 distinct outcomes → l=2 passes."""
+    rows = [
+        {"AGE": "25-34", "SEX": "F", "OUTCOME": "CURED"},
+        {"AGE": "25-34", "SEX": "F", "OUTCOME": "DIED"},
+        {"AGE": "25-34", "SEX": "F", "OUTCOME": "CURED"},
+        {"AGE": "25-34", "SEX": "F", "OUTCOME": "DIED"},
+        {"AGE": "25-34", "SEX": "F", "OUTCOME": "CURED"},
+    ]
+    result = l_diversity_check(
+        rows,
+        quasi_identifiers=("AGE", "SEX"),
+        sensitive_attributes=("OUTCOME",),
+        l_threshold=2,
+    )
+    assert result.blocked is False
+    assert result.smallest_diversity == 2
+
+
+def test_l_diversity_blocks_homogeneous_class() -> None:
+    """All 5 rows in one class share OUTCOME=DIED → l=2 blocks."""
+    rows = [
+        {"AGE": "65+", "SEX": "M", "OUTCOME": "DIED"},
+        {"AGE": "65+", "SEX": "M", "OUTCOME": "DIED"},
+        {"AGE": "65+", "SEX": "M", "OUTCOME": "DIED"},
+        {"AGE": "65+", "SEX": "M", "OUTCOME": "DIED"},
+        {"AGE": "65+", "SEX": "M", "OUTCOME": "DIED"},
+    ]
+    result = l_diversity_check(
+        rows,
+        quasi_identifiers=("AGE", "SEX"),
+        sensitive_attributes=("OUTCOME",),
+        l_threshold=2,
+    )
+    assert result.blocked is True
+    assert result.smallest_diversity == 1
+    assert ("65+|M", "OUTCOME") in result.violating_classes
+
+
+def test_l_diversity_empty_rows_passes() -> None:
+    """No rows → not blocked (caller decides about empty)."""
+    result = l_diversity_check(
+        [],
+        quasi_identifiers=("AGE",),
+        sensitive_attributes=("OUTCOME",),
+        l_threshold=2,
+    )
+    assert result.blocked is False
+
+
+def test_l_diversity_validates_inputs() -> None:
+    rows = [{"x": 1}]
+    with pytest.raises(ValueError):
+        l_diversity_check(rows, quasi_identifiers=(), sensitive_attributes=("x",))
+    with pytest.raises(ValueError):
+        l_diversity_check(rows, quasi_identifiers=("x",), sensitive_attributes=())
+    with pytest.raises(ValueError):
+        l_diversity_check(
+            rows,
+            quasi_identifiers=("x",),
+            sensitive_attributes=("y",),
+            l_threshold=0,
+        )
+
+
+# ── guard_rows_with_kanon_and_ldiv ──────────────────────────────────────────
+
+
+def test_guard_passes_when_both_gates_satisfied() -> None:
+    rows = [
+        {"AGE": "25-34", "SEX": "F", "OUTCOME": "CURED"},
+        {"AGE": "25-34", "SEX": "F", "OUTCOME": "DIED"},
+        {"AGE": "25-34", "SEX": "F", "OUTCOME": "CURED"},
+        {"AGE": "25-34", "SEX": "F", "OUTCOME": "DIED"},
+        {"AGE": "25-34", "SEX": "F", "OUTCOME": "CURED"},
+    ]
+    surfaced, kanon, ldiv = guard_rows_with_kanon_and_ldiv(
+        rows,
+        quasi_identifiers=("AGE", "SEX"),
+        sensitive_attributes=("OUTCOME",),
+        k=5,
+        l_threshold=2,
+        tool_name="test",
+    )
+    assert len(surfaced) == 5
+    assert kanon.blocked is False
+    assert ldiv is not None and ldiv.blocked is False
+
+
+def test_guard_blocks_on_kanon() -> None:
+    """3 rows in a single class with k=5 → k-anon blocks; l-diversity
+    is never reached, so its result is None (we short-circuit)."""
+    rows = [
+        {"AGE": "70+", "SEX": "M", "OUTCOME": "CURED"},
+        {"AGE": "70+", "SEX": "M", "OUTCOME": "CURED"},
+        {"AGE": "70+", "SEX": "M", "OUTCOME": "DIED"},
+    ]
+    surfaced, kanon, ldiv = guard_rows_with_kanon_and_ldiv(
+        rows,
+        quasi_identifiers=("AGE", "SEX"),
+        sensitive_attributes=("OUTCOME",),
+        tool_name="test",
+    )
+    assert surfaced == []
+    assert kanon.blocked is True
+    assert ldiv is None  # short-circuited
+
+
+def test_guard_blocks_on_ldiv_after_kanon_passes() -> None:
+    """k-anon passes (5 rows, single class) but homogeneity blocks."""
+    rows = [
+        {"AGE": "65+", "SEX": "M", "OUTCOME": "DIED"} for _ in range(5)
+    ]
+    surfaced, kanon, ldiv = guard_rows_with_kanon_and_ldiv(
+        rows,
+        quasi_identifiers=("AGE", "SEX"),
+        sensitive_attributes=("OUTCOME",),
+        tool_name="test",
+    )
+    assert surfaced == []
+    assert kanon.blocked is False
+    assert ldiv is not None and ldiv.blocked is True
+
+
+def test_guard_skips_ldiv_when_no_sensitive_attributes() -> None:
+    """``sensitive_attributes=None`` reverts to k-anon-only behavior."""
+    rows = [{"AGE": "25-34", "SEX": "F"} for _ in range(5)]
+    surfaced, kanon, ldiv = guard_rows_with_kanon_and_ldiv(
+        rows,
+        quasi_identifiers=("AGE", "SEX"),
+        sensitive_attributes=None,
+        tool_name="test",
+    )
+    assert len(surfaced) == 5
+    assert kanon.blocked is False
+    assert ldiv is None
+
+
+# ── query_dataset integration ───────────────────────────────────────────────
+
+
+def _seed_trio_with_rows(tmp_path: Path, rows: list[dict[str, Any]], dataset: str = "1A_ICScreening") -> None:
+    """Write *rows* to a tmp trio_bundle/datasets/{dataset}.jsonl + monkeypatch
+    config to point at it."""
+    ds_dir = tmp_path / "trio_bundle" / "datasets"
+    ds_dir.mkdir(parents=True)
+    (ds_dir / f"{dataset}.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in rows), encoding="utf-8"
+    )
+
+
+def test_query_dataset_blocks_when_a_filter_returns_a_small_class(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for 2026-04-27 audit: ``query_dataset`` MUST invoke the
+    k-anon gate. Filter to a single rare combination → result must be
+    suppressed with a ``kanon_violation`` envelope, not raw rows."""
+    import config
+
+    rows = [
+        {"SUBJID": f"SUBJ-{i}", "AGEY": 30, "IS_SEX": "F", "OUTCOME": "CURED"}
+        for i in range(20)
+    ] + [
+        {"SUBJID": "SUBJ-99", "AGEY": 88, "IS_SEX": "M", "OUTCOME": "DIED"}
+    ]
+    _seed_trio_with_rows(tmp_path, rows)
+    monkeypatch.setattr(
+        config, "TRIO_DATASETS_DIR", tmp_path / "trio_bundle" / "datasets"
+    )
+    # Patch the zone marker so the unit test isn't fighting the
+    # frozen-at-import production zone (the actual zone enforcement is
+    # exercised by tests/test_secure_env.py + tests/test_file_access.py).
+    import scripts.ai_assistant.agent_tools as ag
+
+    monkeypatch.setattr(ag, "assert_trio_bundle_zone", lambda _p: None)
+    monkeypatch.setattr(ag, "validate_agent_read", lambda p: p)
+
+    from scripts.ai_assistant.agent_tools import query_dataset
+
+    out = json.loads(
+        query_dataset.invoke(
+            {
+                "dataset_name": "1A_ICScreening",
+                "filter_column": "AGEY",
+                "filter_value": "88",
+            }
+        )
+    )
+    assert out["kanon_violation"] is not None
+    assert out["kanon_violation"]["gate"] in ("kanon", "l_diversity")
+    assert out["records"] == []
+    assert "smallest_class_size" in out["kanon_violation"]
+
+
+def test_query_dataset_passes_through_safe_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A query whose result has every QI class ≥ 5 must surface rows
+    normally with ``kanon_violation: null``."""
+    import config
+
+    # 20 rows, all in the same QI class — k-anon class size = 20, passes.
+    rows = [
+        {"SUBJID": f"SUBJ-{i:03d}", "AGEY": 30, "IS_SEX": "F"}
+        for i in range(20)
+    ]
+    _seed_trio_with_rows(tmp_path, rows, dataset="2A_Demographics")
+    monkeypatch.setattr(
+        config, "TRIO_DATASETS_DIR", tmp_path / "trio_bundle" / "datasets"
+    )
+    import scripts.ai_assistant.agent_tools as ag
+
+    monkeypatch.setattr(ag, "assert_trio_bundle_zone", lambda _p: None)
+    monkeypatch.setattr(ag, "validate_agent_read", lambda p: p)
+
+    from scripts.ai_assistant.agent_tools import query_dataset
+
+    out = json.loads(query_dataset.invoke({"dataset_name": "2A_Demographics"}))
+    assert out["kanon_violation"] is None
+    assert len(out["records"]) > 0


### PR DESCRIPTION
## Summary

Closes the two highest-impact items from Phase 3 of the implementation plan:

- **3.A** Mandatory k-anonymity on row-returning tools (`query_dataset`, `cross_reference_variables`)
- **3.B** l-diversity check (homogeneity-attack defense — documented gap in `kanon_gate.py:19-21`)

After merge: a small version-bump PR ships **v0.18.0** (`feat:` Conventional Commit → minor bump).

## What changed

### New: `LDiversityResult` + `l_diversity_check()` in `scripts/security/kanon_gate.py`

Verifies every equivalence class contains ≥ `l_threshold` distinct values for every sensitive attribute. Defends against the case where 5+ rows in a class share `OUTCOME=DIED` and are therefore re-identifiable despite k-anonymity.

### New: `guard_rows_with_kanon_and_ldiv()` in `scripts/ai_assistant/phi_safe.py`

Runs k-anon then (optionally) l-diversity in sequence. Backward-compatible with the existing `guard_rows_with_kanon`.

### Tool integration in `scripts/ai_assistant/agent_tools.py`

- **`query_dataset` (row-returning)**: invokes the gate before serializing. When blocked, response carries a `kanon_violation` envelope describing which gate fired, `smallest_class_size`, the QI set, and guidance for the LLM. **Rows are NEVER surfaced when blocked.**
- **`cross_reference_variables` (count-returning)**: uses `mask_small_cell()` so any per-dataset count below k=5 is surfaced as `"<5"`. Completeness percentage is recomputed against the masked numerator (can't reverse by arithmetic).

### QI defaults

Conservative Indo-VAP-aware defaults: `("AGE", "AGEY", "AGEM", "SEX", "IS_SEX", "IC_SEX", "DISTRICT", ...)` for QIs and `("EE_DIED", "TB_DX", "OUTCOME", ...)` for sensitive attributes. The `_present_columns` helper picks only QIs actually present in the result — datasets without these columns are pass-through (no false positives).

**Phase 4** will elevate to a per-dataset registry driven by the data dictionary. This PR's hardcoded defaults are explicitly conservative for the Indo-VAP scope.

## Tests

`tests/security/test_kanon_l_diversity.py` — 10 new tests:

1-4. `l_diversity_check` correctness: diverse class passes, homogeneous class blocks, empty input passes, input validation
5-8. `guard_rows_with_kanon_and_ldiv` sequencing: both pass / k-anon blocks / l-div blocks / sensitive=None skips l-div
9. **`query_dataset` regression** — filters to a single rare row → `kanon_violation` envelope, `records=[]`
10. **`query_dataset` happy path** — 20 rows in a single class of 20 → rows surfaced normally

Test #9 is the regression backstop for the original audit finding that the gate helper existed but no production tool called it.

## Verification (no-breakage rule)

- [x] Ruff strict ✓
- [x] Doc-freshness linter ✓
- [x] Full suite: **878 pass + 3 Linux-skip** (was 868; +10 new tests)
- [x] **Live LLM smoke**: `ChatAnthropic` instantiates end-to-end ✓
- [ ] Linux CI exercises the same on Python 3.11/3.12/3.13

## Phase 3 progress

Closes 3.A + 3.B. Remaining Phase 3 items:

- 3.F-H PDF redaction pipeline (vision API)
- 3.I traceback PHI sanitiser
- N4 parallel `main.py` lock
- N6 atomic publish copytree fallback
- 3.C/D/E/J/K (deferred)
- 3.L IRB operator runbooks (non-code)

## Next bump

`feat:` Conventional Commit → minor bump: **0.17.2 → 0.18.0**. The new `kanon_violation` envelope in `query_dataset`'s response is a public-API change for any tool that consumes its output (currently only the LLM agent + the LangChain tool wrapper).