### PR TITLE
chore: bump 0.17.2 → 0.18.0 (Phase 3.A + 3.B kanon + l-diversity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,10 +494,10 @@ uv run python main.py --version
 
 | Commit Message | Version Bump | Example |
 |----------------|--------------|---------|
-| `fix: ...` | **Patch** | 0.17.2 → 0.17.3 |
-| `feat: ...` | **Minor** | 0.17.2 → 0.18.0 |
-| `feat!: ...` or `BREAKING CHANGE:` | **Major** | 0.17.2 → 1.0.0 |
-| Other (docs, chore, refactor, style, test) | **No bump** | 0.17.2 (unchanged) |
+| `fix: ...` | **Patch** | 0.18.0 → 0.18.1 |
+| `feat: ...` | **Minor** | 0.18.0 → 0.19.0 |
+| `feat!: ...` or `BREAKING CHANGE:` | **Major** | 0.18.0 → 1.0.0 |
+| Other (docs, chore, refactor, style, test) | **No bump** | 0.18.0 (unchanged) |
 
 **Via Git hooks (automatic):** commit normally — the post-commit hook analyses
 the message and bumps the version automatically:
@@ -659,4 +659,4 @@ details.
 
 ---
 
-**Version**: 0.17.2 | **Status**: Beta (Active Development — Single-Study Mode)
+**Version**: 0.18.0 | **Status**: Beta (Active Development — Single-Study Mode)

--- a/__version__.py
+++ b/__version__.py
@@ -28,7 +28,7 @@ __all__ = ["__version__", "__version_info__"]
 # Semantic Versioning normal version: X.Y.Z with no leading zeroes except zero itself.
 _SEMVER_CORE_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
-__version__: str = "0.17.2"
+__version__: str = "0.18.0"
 """Canonical repository version in ``MAJOR.MINOR.PATCH`` form."""
 
 _match = _SEMVER_CORE_RE.fullmatch(__version__)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 app:
   name: RePORT AI Portal
-  version: "0.17.2"
+  version: "0.18.0"
   mode: user
   log_level: INFO
 

--- a/docs/irb_dossier/phase3_phi_followups.md
+++ b/docs/irb_dossier/phase3_phi_followups.md
@@ -2,7 +2,7 @@
 
 **Audit dates:** 2026-04-27 (three passes: initial / deeper sweep / extraction-pipeline + scrub-internals + PR re-verify)
 **Author of plan:** in-house security audit
-**Closure status as of v0.17.2:** PRs #10 + #11 close 17 of 23 actionable items (P1a-f + P2-P6 + N1-N3 + N5 + N11-N12). Remaining items are Phase 3 architectural work documented below.
+**Closure status as of v0.18.0:** PRs #10, #11, and #13 close 19 of 23 actionable items (P1a-f + P2-P6 + N1-N3 + N5 + N11-N12 + 3.A + 3.B). Remaining items are Phase 3 architectural work (3.F-H PDF redaction, 3.I traceback sanitiser, N4 parallel-run lock, N6 atomic publish) plus deferred items (3.C/D/E/J/K) plus operator runbooks (3.L).
 
 ---
 
@@ -47,11 +47,16 @@ The honest current statement is: *"PHI architecture is Phase-2-ready for single-
 | **N11** | Indo-VAP `IS_SCRNNUM`/`IC_SCRNNUM` covered by `id_fields` rule |
 | **N12** | Sandbox `_sandbox_result.json` manifest chmod'd 0o600 (PR #10 missed this) |
 
+### ✅ Closed by PR #13 (`feat/phase3-kanon-l-diversity`)
+
+| Item | Closes |
+|---|---|
+| **3.A** | Mandatory k-anonymity on row-returning tools — `query_dataset` now invokes `guard_rows_with_kanon_and_ldiv` before serializing. When blocked, response carries a `kanon_violation` envelope; rows never surface. `cross_reference_variables` uses `mask_small_cell` on per-dataset counts (counts < 5 → `"<5"` label, completeness % recomputed against masked numerator) |
+| **3.B** | l-diversity check — new `l_diversity_check(rows, sensitive_attributes, l_threshold=2)` in `kanon_gate.py`; integrated into `guard_rows_with_kanon_and_ldiv` so a k-anonymous class that's homogeneous on outcome (e.g., 5 rows all `OUTCOME=DIED`) is also blocked. Default sensitive set: `EE_DIED`, `TB_DX`, `OUTCOME`, `DEATHCAUSE`, etc. |
+
 ### 🚧 Remaining for Phase 3 (architectural)
 
-- **3.A** Mandatory k-anonymity on row-returning tools (`query_dataset`, `cross_reference_variables`)
-- **3.B** l-diversity check (kanon_gate.py docstring tracks this gap)
-- **3.F + 3.G + 3.H** PDF redaction pipeline (vision API)
+- **3.F + 3.G + 3.H** PDF redaction pipeline (vision API) — next priority
 - **3.I** Error traceback PHI sanitisation
 - **N4** Parallel `main.py` execution race (file-lock design)
 - **N6** Atomic publish copytree fallback (proper atomic-write pattern)

--- a/docs/sphinx/developer_guide/versioning.rst
+++ b/docs/sphinx/developer_guide/versioning.rst
@@ -15,7 +15,7 @@ The canonical version lives in ``__version__.py`` at the repository root:
 
 .. code-block:: python
 
-   __version__: str = "0.17.2"
+   __version__: str = "0.18.0"
 
 All other modules import from this single source:
 


### PR DESCRIPTION
## Summary

Tracks **PR #13** — first Phase 3 PR. Minor bump (0.17 → 0.18) per Conventional Commits (`feat:` ⇒ minor) because PR #13 introduced new public API + a behavior change on `query_dataset`'s response.

## What v0.18.0 ships (from PR #13)

- New `LDiversityResult` + `l_diversity_check()` in `kanon_gate.py`
- New `guard_rows_with_kanon_and_ldiv()` in `phi_safe.py`
- `query_dataset` now invokes the gate before serializing rows; surfaces a `kanon_violation` envelope when blocked
- `cross_reference_variables` masks small cells (counts < k=5 → `"<5"` label)
- Conservative Indo-VAP-aware QI defaults; pass-through for non-Indo-VAP datasets
- 10 new regression tests including 2 integration tests pinning the `query_dataset` behavior

## Plan-doc update

`docs/irb_dossier/phase3_phi_followups.md` updated with PR #13's closures (3.A + 3.B). 19 of 23 actionable items closed across PRs #10/#11/#13.

## Verification

- [x] Doc-freshness linter green at `__version__=0.18.0`
- [x] Full suite: **878 pass + 3 Linux-skip**
- [ ] CI green on this PR

## After merge

I'll tag `v0.18.0` + create the GitHub Release, then start PR #14 — the PDF redaction pipeline (3.F-H). Will pause for design sign-off before that one since it's substantial architectural work touching the vision API path.