### PR TITLE
feat(wizard): PDF-extraction-mode radio (snapshot vs LLM)

### DIFF
--- a/scripts/ai_assistant/ui/wizard.py
+++ b/scripts/ai_assistant/ui/wizard.py
@@ -169,6 +169,11 @@ def run_pipeline() -> dict[str, Any]:
     we inject them only into this single subprocess call via the
     KeyStore's ``env_for_subprocess`` helper. The parent's env stays
     clean before, during, and after the call.
+
+    The operator's PDF-extraction-mode choice (radio in step 2) is
+    propagated through ``REPORTALIN_PDF_EXTRACTION_MODE`` so the
+    subprocess's ``extract_pdfs_to_jsonl`` dispatcher can pick the
+    snapshot or orchestrator path.
     """
     import os
 
@@ -184,6 +189,10 @@ def run_pipeline() -> dict[str, Any]:
         get_keystore().env_for_subprocess(list(ENV_VAR_BY_PROVIDER))
     )
 
+    selected_mode = str(st.session_state.get("pdf_extraction_mode", "snapshot")).strip().lower()
+    if selected_mode in {"llm", "snapshot"}:
+        subprocess_env["REPORTALIN_PDF_EXTRACTION_MODE"] = selected_mode
+
     result = subprocess.run(  # noqa: S603
         [sys.executable, str(config.BASE_DIR / "main.py"), "--pipeline"],
         capture_output=True,
@@ -193,6 +202,48 @@ def run_pipeline() -> dict[str, Any]:
     )
     combined = (result.stdout + "\n" + result.stderr).strip()
     return {"success": result.returncode == 0, "output": combined}
+
+
+def _resolve_pdf_mode_options() -> tuple[list[str], bool, str, str]:
+    """Return ``(options, llm_capable, provider_id, model_id)`` for the
+    PDF-extraction radio in step 2.
+
+    Snapshot is always available. The LLM option is offered only when
+    BOTH:
+
+    1. The configured model is on the ``llm_capabilities`` allowlist
+       (rules out small / unreliable models even from supported
+       providers — e.g. claude-haiku-3, gemini-flash).
+    2. The provider's LLM tier is actually wired in
+       :data:`pdf_pipeline.ORCHESTRATOR_SUPPORTED_PROVIDERS` (currently
+       anthropic + google). Otherwise the operator would silently get
+       a snapshot fallback after picking "fresh LLM" — a regression vs
+       the legacy raw-PDF API path which raised an explicit error.
+    """
+    from scripts.extraction.pdf_pipeline import ORCHESTRATOR_SUPPORTED_PROVIDERS
+    from scripts.utils.llm_capabilities import is_capable_model
+
+    label = st.session_state.get("llm_provider_label", _default_provider_label())
+    cfg = _PROVIDER_CONFIG.get(label, {})
+    provider_id = str(cfg.get("provider") or "")
+    model_id = str(st.session_state.get("llm_model", "") or "")
+    # Orchestrator capability uses ``google`` (not ``google-genai``).
+    capability_provider = "google" if provider_id == "google-genai" else provider_id
+
+    capable = (
+        is_capable_model(capability_provider, model_id)
+        and provider_id in ORCHESTRATOR_SUPPORTED_PROVIDERS
+    )
+    options = ["snapshot"]
+    if capable:
+        options.append("llm")
+    return options, capable, provider_id, model_id
+
+
+_PDF_MODE_LABELS: dict[str, str] = {
+    "snapshot": "Use existing study data (verified snapshot)",
+    "llm": "Generate fresh PDF extraction (LLM-assisted)",
+}
 
 
 def _pipeline_output_exists() -> bool:
@@ -410,6 +461,30 @@ def render_setup_page() -> None:
 
                 output_exists = _pipeline_output_exists()
                 pipeline_ready: bool = st.session_state.pipeline_ready
+
+                # ── PDF-extraction mode radio (Phase 3 PR #16) ─────────────
+                # Operator choice: regenerate extraction with an LLM
+                # (only when a vision-capable model is configured) or
+                # publish the verified initial snapshot verbatim.
+                mode_options, llm_capable, _prov_id, _model_id = (
+                    _resolve_pdf_mode_options()
+                )
+                if st.session_state.get("pdf_extraction_mode") not in mode_options:
+                    st.session_state.pdf_extraction_mode = mode_options[0]
+                st.radio(
+                    "PDF extraction source",
+                    options=mode_options,
+                    format_func=lambda v: _PDF_MODE_LABELS.get(v, v),
+                    horizontal=True,
+                    key="pdf_extraction_mode",
+                )
+                if not llm_capable:
+                    st.caption(
+                        "💡 Fresh LLM extraction needs a vision-capable model "
+                        "from a wired provider (Anthropic Claude Opus/Sonnet 4.6+ "
+                        "or Google Gemini 2.5 Pro). Pick one in step 1 to unlock "
+                        "that option."
+                    )
 
                 if pipeline_ready:
                     st.success("Study data loaded — ready for querying.", icon="✅")

--- a/scripts/extraction/extract_pdf_data.py
+++ b/scripts/extraction/extract_pdf_data.py
@@ -99,6 +99,47 @@ RESULT_PROCESSING_TIME: str = "processing_time"
 
 INTER_PDF_DELAY: float = config.PDF_EXTRACTION_INTER_DELAY
 
+
+# ---------------------------------------------------------------------------
+# Extraction mode selector (Phase 3 PR #16)
+# ---------------------------------------------------------------------------
+# The wizard surfaces a binary choice to the operator:
+#
+#   1. ``llm``      — generate fresh PDF extraction via the orchestrator in
+#                     ``scripts.extraction.pdf_pipeline`` (text redaction +
+#                     capable-LLM call + snapshot fallback per-PDF when the
+#                     LLM can't handle a form).
+#   2. ``snapshot`` — skip the LLM entirely and publish the human-verified
+#                     baseline JSONs from
+#                     ``output/{STUDY}/agent/snapshots/initial/pdfs/``.
+#
+# When :data:`_PDF_EXTRACTION_MODE_ENV` is unset, ``extract_pdfs_to_jsonl``
+# falls back to the legacy raw-PDF API path (gated by the two-part
+# ``REPORTALIN_PDF_PHI_FREE`` + attestation note). The legacy path remains
+# the CLI default so existing automation does not change behaviour.
+_PDF_EXTRACTION_MODE_ENV: str = "REPORTALIN_PDF_EXTRACTION_MODE"
+_PDF_EXTRACTION_MODE_LLM: str = "llm"
+_PDF_EXTRACTION_MODE_SNAPSHOT: str = "snapshot"
+_PDF_EXTRACTION_MODES: frozenset[str] = frozenset(
+    {_PDF_EXTRACTION_MODE_LLM, _PDF_EXTRACTION_MODE_SNAPSHOT}
+)
+
+
+def _pdf_extraction_mode() -> str:
+    """Return the configured extraction mode (``"llm"`` / ``"snapshot"``),
+    or ``""`` when the env var is unset / unrecognised (legacy path)."""
+    raw = os.environ.get(_PDF_EXTRACTION_MODE_ENV, "").strip().lower()
+    return raw if raw in _PDF_EXTRACTION_MODES else ""
+
+
+def _initial_snapshot_pdfs_dir() -> Path:
+    """``output/{STUDY}/agent/snapshots/initial/pdfs/`` — the canonical
+    location of the human-verified baseline PDF JSONs the snapshot mode
+    publishes verbatim. Layout matches ``trio_bundle/pdfs/`` (one
+    ``{stem}_variables.json`` per form)."""
+    return Path(config.STUDY_SNAPSHOTS_DIR) / "initial" / "pdfs"
+
+
 __all__ = [
     "clean_existing_jsons",
     "extract_pdfs_to_jsonl",
@@ -741,6 +782,194 @@ def _empty_result(
 # --- Main orchestration ---
 
 
+def _run_snapshot_mode(
+    pdf_files: list[Path],
+    dest_dir: Path,
+    *,
+    force: bool,
+) -> tuple[int, int, int, list[dict[str, str]]]:
+    """Publish the verified baseline JSONs verbatim — no LLM call.
+
+    For each annotated PDF, copy the matching
+    ``{stem}_variables.json`` from
+    ``output/{STUDY}/agent/snapshots/initial/pdfs/`` into ``dest_dir``.
+    A missing snapshot is reported as an error (the form will simply be
+    absent from the published bundle); it is NOT a fatal failure.
+    """
+    snapshot_dir = _initial_snapshot_pdfs_dir()
+    log.info("PDF extraction: snapshot mode — using %s", snapshot_dir)
+
+    if not snapshot_dir.is_dir():
+        msg = (
+            f"Snapshot directory not found: {snapshot_dir}. "
+            "Run --pipeline once with REPORTALIN_PDF_EXTRACTION_MODE=llm "
+            "or seed initial snapshots."
+        )
+        log.error(msg)
+        return 0, 0, 0, [{"file": "", "error": msg}]
+
+    total_vars, files_created, files_skipped = 0, 0, 0
+    errors: list[dict[str, str]] = []
+
+    for idx, pdf_path in enumerate(pdf_files, 1):
+        stem = pdf_path.stem
+        json_out = dest_dir / f"{stem}{JSON_VARIABLES_SUFFIX}"
+
+        if not force and json_out.exists() and check_json_integrity(json_out):
+            files_skipped += 1
+            log.info(
+                "  [%d/%d] Skipping %s (valid output exists)",
+                idx,
+                len(pdf_files),
+                pdf_path.name,
+            )
+            continue
+
+        snap_path = snapshot_dir / f"{stem}{JSON_VARIABLES_SUFFIX}"
+        if not snap_path.is_file():
+            alt = snapshot_dir / f"{stem}.json"
+            snap_path = alt if alt.is_file() else snap_path
+
+        if not snap_path.is_file():
+            msg = f"No snapshot for {pdf_path.name}: expected {snap_path.name}"
+            log.warning(msg)
+            errors.append({"file": pdf_path.name, "error": msg})
+            continue
+
+        try:
+            data = json.loads(snap_path.read_text(encoding=FILE_ENCODING))
+        except (json.JSONDecodeError, OSError) as exc:
+            errors.append({"file": pdf_path.name, "error": f"snapshot unreadable: {exc}"})
+            continue
+
+        if not isinstance(data, dict):
+            errors.append({"file": pdf_path.name, "error": "snapshot is not a JSON object"})
+            continue
+
+        data["extraction_tier"] = "snapshot"
+        atomic_write_json(json_out, data, prefix=NAMED_TEMP_PREFIX)
+        files_created += 1
+        total_vars += len(data.get("variables", {}) or {})
+        log.info("  [%d/%d] %s ← snapshot", idx, len(pdf_files), pdf_path.name)
+
+    return total_vars, files_created, files_skipped, errors
+
+
+def _resolve_orchestrator_credentials() -> tuple[str | None, str | None, str | None]:
+    """Pull provider/model/api_key from the subprocess env (the wizard
+    populates ``ANTHROPIC_API_KEY``/``GOOGLE_API_KEY`` via the KeyStore's
+    ``env_for_subprocess`` helper before spawning ``main.py``).
+
+    Unlike :func:`_resolve_pdf_provider`, no PHI-free attestation gate is
+    required: the orchestrator redacts PHI from extracted text before any
+    byte leaves the host (it never sends raw PDF bytes), so the audit
+    posture is fundamentally different.
+
+    Returns ``(provider, model, api_key)``; any element may be ``None``,
+    in which case :func:`pdf_pipeline.extract_pdf` will skip the LLM tier
+    for that PDF and fall back to the snapshot.
+    """
+    provider = os.environ.get("LLM_PROVIDER", "").strip().lower()
+    if provider == "google-genai":
+        provider = "google"
+    if not provider:
+        return None, None, None
+
+    model = os.environ.get("LLM_MODEL", "").strip() or None
+
+    api_key_env = {
+        "anthropic": "ANTHROPIC_API_KEY",
+        "google": "GOOGLE_API_KEY",
+    }.get(provider)
+    api_key = (
+        os.environ.get(api_key_env, "").strip() if api_key_env else ""
+    ) or None
+
+    return provider, model, api_key
+
+
+def _run_orchestrator_mode(
+    pdf_files: list[Path],
+    dest_dir: Path,
+    *,
+    force: bool,
+) -> tuple[int, int, int, list[dict[str, str]]]:
+    """Run the two-way orchestrator (``pdf_pipeline.extract_pdf``) per PDF.
+
+    Each form goes through redacted-text → capable-LLM-call → merge with
+    code candidate, and falls back to the verified ``initial`` snapshot
+    when the LLM tier is unavailable. The orchestrator's idempotent cache
+    lives under ``tmp/{STUDY}/.pdf_cache/``.
+    """
+    from scripts.extraction.pdf_pipeline import extract_pdf
+
+    provider, model, api_key = _resolve_orchestrator_credentials()
+    snapshot_dir = _initial_snapshot_pdfs_dir()
+    cache_dir = Path(config.STUDY_STAGING_DIR) / ".pdf_cache"
+    log.info(
+        "PDF extraction: orchestrator mode — provider=%s model=%s "
+        "snapshot_dir=%s cache_dir=%s",
+        provider,
+        model,
+        snapshot_dir,
+        cache_dir,
+    )
+
+    total_vars, files_created, files_skipped = 0, 0, 0
+    errors: list[dict[str, str]] = []
+
+    with vlog.file_processing("PDF extraction (orchestrator)", total_records=len(pdf_files)):
+        for idx, pdf_path in enumerate(pdf_files, 1):
+            stem = pdf_path.stem
+            json_out = dest_dir / f"{stem}{JSON_VARIABLES_SUFFIX}"
+
+            if not force and json_out.exists() and check_json_integrity(json_out):
+                files_skipped += 1
+                log.info(
+                    "  [%d/%d] Skipping %s (valid output exists)",
+                    idx,
+                    len(pdf_files),
+                    pdf_path.name,
+                )
+                continue
+
+            try:
+                result = extract_pdf(
+                    pdf_path,
+                    provider=provider,
+                    model=model,
+                    api_key=api_key,
+                    snapshot_dir=snapshot_dir if snapshot_dir.is_dir() else None,
+                    cache_dir=cache_dir,
+                )
+            except Exception as exc:  # never let one PDF crash the run
+                errors.append({"file": pdf_path.name, "error": str(exc)})
+                log.error("orchestrator failed for %s: %s", pdf_path.name, exc)
+                continue
+
+            if result.tier == "empty":
+                msg = (
+                    f"orchestrator produced no extractable variables "
+                    f"(llm_skipped={result.llm_skipped_reason!r})"
+                )
+                errors.append({"file": pdf_path.name, "error": msg})
+                continue
+
+            atomic_write_json(json_out, result.data, prefix=NAMED_TEMP_PREFIX)
+            files_created += 1
+            total_vars += len(result.data.get("variables", {}) or {})
+            log.info(
+                "  [%d/%d] %s ← %s%s",
+                idx,
+                len(pdf_files),
+                pdf_path.name,
+                result.tier,
+                " (cache hit)" if result.cache_hit else "",
+            )
+
+    return total_vars, files_created, files_skipped, errors
+
+
 def extract_pdfs_to_jsonl(
     pdf_dir: Path | None = None,
     output_dir: Path | None = None,
@@ -748,8 +977,18 @@ def extract_pdfs_to_jsonl(
 ) -> dict[str, Any]:
     """Extract all annotated PDFs into structured JSON outputs.
 
-    Discovers PDFs, initializes one LLM client, and writes per-form
-    structured JSON (``_variables.json``) files.
+    Discovers PDFs and writes per-form structured JSON
+    (``_variables.json``) files. The actual extraction strategy depends
+    on the :data:`_PDF_EXTRACTION_MODE_ENV` env var, which the wizard
+    sets per the operator's choice:
+
+    - ``llm``      — :func:`_run_orchestrator_mode` (text-redacted LLM
+                     call paired with code path; snapshot fallback per-PDF).
+    - ``snapshot`` — :func:`_run_snapshot_mode` (publish verified baseline
+                     JSONs verbatim; no LLM call).
+    - unset        — legacy raw-PDF API path
+                     (:func:`_resolve_pdf_provider`-gated). Preserves
+                     existing CLI behaviour.
 
     .. note::
        Despite its name (kept for backward compatibility), this function now
@@ -794,55 +1033,68 @@ def extract_pdfs_to_jsonl(
 
     dest_dir.mkdir(parents=True, exist_ok=True)
 
-    # Initialize LLM provider
-    try:
-        provider, client, model, extras = _resolve_pdf_provider()
-        log.info("PDF extraction: provider=%s, model=%s", provider, model)
-    except Exception as e:
-        msg = f"Failed to initialize LLM client: {e}"
-        log.error(msg)
-        return _empty_result(
-            files_found=len(pdf_files),
-            errors=[{"file": "", "error": msg}],
+    # Mode dispatch ─────────────────────────────────────────────────────
+    mode = _pdf_extraction_mode()
+
+    if mode == _PDF_EXTRACTION_MODE_SNAPSHOT:
+        total_vars, files_created, files_skipped, errors = _run_snapshot_mode(
+            pdf_files, dest_dir, force=force
         )
-
-    total_vars, files_created, files_skipped = 0, 0, 0
-    errors: list[dict[str, str]] = []
-
-    with vlog.file_processing("PDF extraction", total_records=len(pdf_files)):
-        for idx, pdf_path in enumerate(pdf_files, 1):
-            json_out = dest_dir / f"{pdf_path.stem}{JSON_VARIABLES_SUFFIX}"
-
-            if not force and json_out.exists() and check_json_integrity(json_out):
-                files_skipped += 1
-                log.info(
-                    "  [%d/%d] Skipping %s (valid output exists)",
-                    idx,
-                    len(pdf_files),
-                    pdf_path.name,
-                )
-                continue
-
-            log.info("  [%d/%d] Extracting %s", idx, len(pdf_files), pdf_path.name)
-
-            success, count, error_msg = process_single_pdf(
-                pdf_path,
-                dest_dir,
-                client,
-                model,
-                provider=provider,
-                **extras,
+    elif mode == _PDF_EXTRACTION_MODE_LLM:
+        total_vars, files_created, files_skipped, errors = _run_orchestrator_mode(
+            pdf_files, dest_dir, force=force
+        )
+    else:
+        # Legacy raw-PDF API path (CLI default; gated by the two-part
+        # PHI-free attestation in ``_resolve_pdf_provider``).
+        try:
+            provider, client, model, extras = _resolve_pdf_provider()
+            log.info("PDF extraction: provider=%s, model=%s", provider, model)
+        except Exception as e:
+            msg = f"Failed to initialize LLM client: {e}"
+            log.error(msg)
+            return _empty_result(
+                files_found=len(pdf_files),
+                errors=[{"file": "", "error": msg}],
             )
 
-            if success:
-                files_created += 1
-                total_vars += count
-            elif error_msg:
-                errors.append({"file": pdf_path.name, "error": error_msg})
+        total_vars, files_created, files_skipped = 0, 0, 0
+        errors = []
 
-            # Rate-limit between API calls
-            if idx < len(pdf_files):
-                time.sleep(INTER_PDF_DELAY)
+        with vlog.file_processing("PDF extraction", total_records=len(pdf_files)):
+            for idx, pdf_path in enumerate(pdf_files, 1):
+                json_out = dest_dir / f"{pdf_path.stem}{JSON_VARIABLES_SUFFIX}"
+
+                if not force and json_out.exists() and check_json_integrity(json_out):
+                    files_skipped += 1
+                    log.info(
+                        "  [%d/%d] Skipping %s (valid output exists)",
+                        idx,
+                        len(pdf_files),
+                        pdf_path.name,
+                    )
+                    continue
+
+                log.info("  [%d/%d] Extracting %s", idx, len(pdf_files), pdf_path.name)
+
+                success, count, error_msg = process_single_pdf(
+                    pdf_path,
+                    dest_dir,
+                    client,
+                    model,
+                    provider=provider,
+                    **extras,
+                )
+
+                if success:
+                    files_created += 1
+                    total_vars += count
+                elif error_msg:
+                    errors.append({"file": pdf_path.name, "error": error_msg})
+
+                # Rate-limit between API calls
+                if idx < len(pdf_files):
+                    time.sleep(INTER_PDF_DELAY)
 
     # Post-extraction: cross-form duplicate variable removal
     duplicates_removed = 0

--- a/scripts/extraction/pdf_pipeline.py
+++ b/scripts/extraction/pdf_pipeline.py
@@ -66,9 +66,21 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "ORCHESTRATOR_SUPPORTED_PROVIDERS",
     "ExtractionResult",
     "extract_pdf",
 ]
+
+
+# Provider IDs whose LLM tier is wired in :func:`_extract_via_llm`.
+# Sources of truth in one place so the wizard's radio gate and the
+# orchestrator's runtime dispatch can never disagree — the wizard offers
+# the ``llm`` choice ONLY when the configured provider is in this set
+# AND the model passes the capability allowlist. Otherwise the operator
+# would silently get a snapshot fallback after picking "fresh LLM".
+ORCHESTRATOR_SUPPORTED_PROVIDERS: frozenset[str] = frozenset(
+    {"anthropic", "google", "google-genai", "gemini"}
+)
 
 
 # ── Result shape ────────────────────────────────────────────────────────────

--- a/tests/test_extract_pdf_data.py
+++ b/tests/test_extract_pdf_data.py
@@ -176,3 +176,201 @@ class TestExtractPdfsToJsonlDefaultOutput:
         assert explicit.exists()
         # Staging must NOT have been used when caller is explicit.
         assert not config.STAGING_PDFS_DIR.exists()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# extract_pdfs_to_jsonl — REPORTALIN_PDF_EXTRACTION_MODE dispatch (PR #16)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestPdfExtractionModeDispatch:
+    """The wizard's PDF-extraction-source radio sets
+    ``REPORTALIN_PDF_EXTRACTION_MODE`` to ``llm`` or ``snapshot``;
+    ``extract_pdfs_to_jsonl`` dispatches to the matching helper.
+
+    Both helpers must NEVER call ``_resolve_pdf_provider`` (it lives on
+    the legacy raw-PDF API path; it has its own two-part PHI-free
+    attestation gate that the new modes intentionally bypass — the
+    orchestrator redacts text before any byte leaves the host, the
+    snapshot mode never makes an LLM call at all).
+    """
+
+    def _seed_snapshot(self, monkeypatch_config: Path, stem: str, payload: dict) -> Path:
+        snap_dir = monkeypatch_config / "agent" / "snapshots" / "initial" / "pdfs"
+        snap_dir.mkdir(parents=True, exist_ok=True)
+        out = snap_dir / f"{stem}_variables.json"
+        out.write_text(json.dumps(payload), encoding="utf-8")
+        return out
+
+    def test_snapshot_mode_publishes_baseline_verbatim(
+        self,
+        tmp_path: Path,
+        monkeypatch_config: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        pdf_src = tmp_path / "annotated_pdfs"
+        pdf_src.mkdir()
+        (pdf_src / "form_x.pdf").write_bytes(b"%PDF-1.4\n%EOF\n")
+
+        self._seed_snapshot(
+            monkeypatch_config,
+            "form_x",
+            {
+                "form_name": "Form X",
+                "source_pdf": "form_x.pdf",
+                "variables": {"AAA": {"description": "alpha"}},
+            },
+        )
+
+        # Provider must NOT be touched in snapshot mode.
+        def _boom() -> None:
+            raise AssertionError(
+                "_resolve_pdf_provider must not be invoked when mode=snapshot"
+            )
+
+        monkeypatch.setattr(epd, "_resolve_pdf_provider", _boom)
+        monkeypatch.setenv("REPORTALIN_PDF_EXTRACTION_MODE", "snapshot")
+
+        result = extract_pdfs_to_jsonl(pdf_dir=pdf_src)
+
+        assert result["errors"] == [], result["errors"]
+        assert result["files_created"] == 1
+        out = config.STAGING_PDFS_DIR / "form_x_variables.json"
+        assert out.is_file()
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data["variables"] == {"AAA": {"description": "alpha"}}
+        # Tier marker is stamped onto the published JSON for traceability.
+        assert data.get("extraction_tier") == "snapshot"
+
+    def test_snapshot_mode_records_error_on_missing_baseline(
+        self,
+        tmp_path: Path,
+        monkeypatch_config: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        pdf_src = tmp_path / "annotated_pdfs"
+        pdf_src.mkdir()
+        (pdf_src / "form_missing.pdf").write_bytes(b"%PDF-1.4\n%EOF\n")
+        # Snapshot dir exists but is empty for this PDF.
+        (monkeypatch_config / "agent" / "snapshots" / "initial" / "pdfs").mkdir(
+            parents=True, exist_ok=True
+        )
+
+        monkeypatch.setattr(epd, "_resolve_pdf_provider", lambda: (_ for _ in ()).throw(
+            AssertionError("provider must not be called")
+        ))
+        monkeypatch.setenv("REPORTALIN_PDF_EXTRACTION_MODE", "snapshot")
+
+        result = extract_pdfs_to_jsonl(pdf_dir=pdf_src)
+
+        assert result["files_created"] == 0
+        errors = result["errors"]
+        assert errors and "No snapshot for form_missing.pdf" in errors[0]["error"]
+
+    def test_llm_mode_delegates_to_orchestrator(
+        self,
+        tmp_path: Path,
+        monkeypatch_config: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        pdf_src = tmp_path / "annotated_pdfs"
+        pdf_src.mkdir()
+        (pdf_src / "form_y.pdf").write_bytes(b"%PDF-1.4\n%EOF\n")
+
+        # Stub the orchestrator so we don't fire a real LLM call. The dispatch
+        # contract is what we're pinning here.
+        from scripts.extraction import pdf_pipeline as pp
+
+        captured: dict[str, object] = {}
+
+        def _fake_extract(pdf_path: Path, **kw: object):  # type: ignore[no-untyped-def]
+            captured["pdf_path"] = pdf_path
+            captured.update(kw)
+            return pp.ExtractionResult(
+                pdf_name=pdf_path.name,
+                tier="merged",
+                data={
+                    "form_name": "Form Y",
+                    "source_pdf": pdf_path.name,
+                    "variables": {"BBB": {"description": "beta"}},
+                    "extraction_tier": "merged",
+                },
+                llm_succeeded=True,
+                code_succeeded=True,
+            )
+
+        monkeypatch.setattr(pp, "extract_pdf", _fake_extract)
+        monkeypatch.setattr(epd, "_resolve_pdf_provider", lambda: (_ for _ in ()).throw(
+            AssertionError("provider must not be called")
+        ))
+
+        # Wizard subprocess env injection emulation.
+        monkeypatch.setenv("REPORTALIN_PDF_EXTRACTION_MODE", "llm")
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        monkeypatch.setenv("LLM_MODEL", "claude-opus-4-7")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        result = extract_pdfs_to_jsonl(pdf_dir=pdf_src)
+
+        assert result["errors"] == [], result["errors"]
+        assert result["files_created"] == 1
+        # Credentials must have been forwarded to the orchestrator.
+        assert captured.get("provider") == "anthropic"
+        assert captured.get("model") == "claude-opus-4-7"
+        assert captured.get("api_key") == "sk-ant-test"
+        # Cache + snapshot dirs are forwarded so the orchestrator can use them.
+        assert captured.get("cache_dir") is not None
+        # Output written verbatim from orchestrator's `data` field.
+        out = config.STAGING_PDFS_DIR / "form_y_variables.json"
+        assert out.is_file()
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data["variables"] == {"BBB": {"description": "beta"}}
+
+    def test_unset_mode_falls_back_to_legacy_path(
+        self,
+        tmp_path: Path,
+        monkeypatch_config: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When the env var is unset, ``_resolve_pdf_provider`` must still
+        be the entry point (preserves CLI back-compat for users not running
+        the wizard)."""
+        pdf_src = tmp_path / "annotated_pdfs"
+        pdf_src.mkdir()
+        (pdf_src / "legacy.pdf").write_bytes(b"%PDF-1.4\n%EOF\n")
+
+        sentinel = {"called": False}
+
+        def _boom() -> None:
+            sentinel["called"] = True
+            raise ImportError("no provider in tests")
+
+        monkeypatch.setattr(epd, "_resolve_pdf_provider", _boom)
+        monkeypatch.delenv("REPORTALIN_PDF_EXTRACTION_MODE", raising=False)
+
+        extract_pdfs_to_jsonl(pdf_dir=pdf_src)
+        assert sentinel["called"] is True
+
+    def test_unrecognised_mode_falls_back_to_legacy_path(
+        self,
+        tmp_path: Path,
+        monkeypatch_config: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A garbage value behaves like ``unset`` rather than crashing —
+        avoids surprising operators who fat-finger the env var."""
+        pdf_src = tmp_path / "annotated_pdfs"
+        pdf_src.mkdir()
+        (pdf_src / "garbage.pdf").write_bytes(b"%PDF-1.4\n%EOF\n")
+
+        sentinel = {"called": False}
+
+        def _boom() -> None:
+            sentinel["called"] = True
+            raise ImportError("no provider in tests")
+
+        monkeypatch.setattr(epd, "_resolve_pdf_provider", _boom)
+        monkeypatch.setenv("REPORTALIN_PDF_EXTRACTION_MODE", "wibble")
+
+        extract_pdfs_to_jsonl(pdf_dir=pdf_src)
+        assert sentinel["called"] is True

--- a/tests/test_wizard_pdf_mode.py
+++ b/tests/test_wizard_pdf_mode.py
@@ -1,0 +1,228 @@
+"""Tests for wizard PDF-extraction mode plumbing (PR #16).
+
+Pins the contract that:
+
+1. ``run_pipeline()`` propagates ``st.session_state["pdf_extraction_mode"]``
+   into the spawned subprocess via ``REPORTALIN_PDF_EXTRACTION_MODE`` —
+   so the operator's radio choice in step 2 actually reaches
+   ``scripts.extraction.extract_pdf_data.extract_pdfs_to_jsonl``.
+2. ``_resolve_pdf_mode_options()`` only offers the ``llm`` option when
+   the configured model passes the capability allowlist — non-capable
+   selections see ``snapshot`` only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ── run_pipeline env injection ──────────────────────────────────────────────
+
+
+def _stub_subprocess_run(captured: dict[str, Any]) -> MagicMock:
+    """Return a ``subprocess.run`` mock that captures the passed env."""
+
+    def _fake_run(*args: Any, **kw: Any) -> MagicMock:
+        captured["args"] = args
+        captured["env"] = kw.get("env")
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = ""
+        m.stderr = ""
+        return m
+
+    return MagicMock(side_effect=_fake_run)
+
+
+@pytest.mark.parametrize("mode", ["snapshot", "llm"])
+def test_run_pipeline_propagates_mode(
+    mode: str,
+    tmp_path: Path,
+    monkeypatch_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wizard's mode radio selection must reach the subprocess as
+    ``REPORTALIN_PDF_EXTRACTION_MODE``."""
+    from scripts.ai_assistant.ui import wizard
+
+    # Stub PHI key bootstrap (no real disk I/O).
+    monkeypatch.setattr(wizard, "_ensure_phi_key", lambda: None)
+
+    # Stub session_state with the chosen mode. dict-like is enough.
+    fake_ss: dict[str, Any] = {"pdf_extraction_mode": mode}
+    monkeypatch.setattr(wizard.st, "session_state", fake_ss)
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(wizard.subprocess, "run", _stub_subprocess_run(captured))
+
+    out = wizard.run_pipeline()
+    assert out["success"] is True
+
+    env = captured["env"]
+    assert env is not None
+    assert env.get("REPORTALIN_PDF_EXTRACTION_MODE") == mode
+
+
+def test_run_pipeline_defaults_unset_to_snapshot(
+    tmp_path: Path,
+    monkeypatch_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If session_state lacks the mode (e.g. user skipped wizard), the
+    env var defaults to ``snapshot`` — never empty / never invalid."""
+    from scripts.ai_assistant.ui import wizard
+
+    monkeypatch.delenv("REPORTALIN_PDF_EXTRACTION_MODE", raising=False)
+    monkeypatch.setattr(wizard, "_ensure_phi_key", lambda: None)
+    fake_ss: dict[str, Any] = {}
+    monkeypatch.setattr(wizard.st, "session_state", fake_ss)
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(wizard.subprocess, "run", _stub_subprocess_run(captured))
+
+    wizard.run_pipeline()
+    env = captured["env"]
+    assert env.get("REPORTALIN_PDF_EXTRACTION_MODE") == "snapshot"
+
+
+def test_run_pipeline_drops_unrecognised_mode(
+    tmp_path: Path,
+    monkeypatch_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A surprise value (somehow stuck in session_state) must NOT be
+    forwarded — even if ``REPORTALIN_PDF_EXTRACTION_MODE`` is present
+    in the parent env. The wizard must not echo arbitrary garbage; the
+    legacy CLI path runs in the subprocess instead."""
+    from scripts.ai_assistant.ui import wizard
+
+    # Pre-existing parent-env value should be preserved as the fallback —
+    # the wizard's job is to never *introduce* an unrecognised mode.
+    monkeypatch.setenv("REPORTALIN_PDF_EXTRACTION_MODE", "snapshot")
+    monkeypatch.setattr(wizard, "_ensure_phi_key", lambda: None)
+    fake_ss: dict[str, Any] = {"pdf_extraction_mode": "WIBBLE"}
+    monkeypatch.setattr(wizard.st, "session_state", fake_ss)
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(wizard.subprocess, "run", _stub_subprocess_run(captured))
+
+    wizard.run_pipeline()
+    env = captured["env"]
+    # Pre-existing parent-env value preserved; never echoes the garbage.
+    assert env.get("REPORTALIN_PDF_EXTRACTION_MODE") == "snapshot"
+    assert env.get("REPORTALIN_PDF_EXTRACTION_MODE") not in {"WIBBLE", "wibble"}
+
+
+# ── _resolve_pdf_mode_options gating ────────────────────────────────────────
+
+
+def _set_session_state(monkeypatch: pytest.MonkeyPatch, **kw: Any) -> None:
+    """Patch wizard.st.session_state with the supplied keys."""
+    from scripts.ai_assistant.ui import wizard
+
+    monkeypatch.setattr(wizard.st, "session_state", dict(kw))
+
+
+def test_mode_options_capable_model_offers_llm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts.ai_assistant.ui import wizard
+
+    _set_session_state(
+        monkeypatch,
+        llm_provider_label="Anthropic",
+        llm_model="claude-opus-4-7",
+    )
+    options, capable, prov, model = wizard._resolve_pdf_mode_options()
+    assert "snapshot" in options
+    assert "llm" in options
+    assert capable is True
+    assert prov == "anthropic"
+    assert model == "claude-opus-4-7"
+
+
+def test_mode_options_non_capable_model_hides_llm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts.ai_assistant.ui import wizard
+
+    _set_session_state(
+        monkeypatch,
+        llm_provider_label="Anthropic",
+        llm_model="claude-haiku-3",  # not on the capable allowlist
+    )
+    options, capable, _prov, _model = wizard._resolve_pdf_mode_options()
+    assert options == ["snapshot"]
+    assert capable is False
+
+
+def test_mode_options_openai_capable_but_unsupported_by_orchestrator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAI gpt-5 IS on the capability allowlist, but
+    ``pdf_pipeline._extract_via_llm`` only wires anthropic + google —
+    so the wizard must hide the ``llm`` option to prevent the operator
+    from picking it and silently getting a snapshot fallback."""
+    from scripts.ai_assistant.ui import wizard
+
+    _set_session_state(
+        monkeypatch,
+        llm_provider_label="OpenAI",
+        llm_model="gpt-5",
+    )
+    options, capable, prov, _model = wizard._resolve_pdf_mode_options()
+    assert options == ["snapshot"]
+    assert capable is False
+    assert prov == "openai"
+
+
+def test_mode_options_nvidia_capable_but_unsupported_by_orchestrator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same gate for NVIDIA-hosted Llama 3.3 405B."""
+    from scripts.ai_assistant.ui import wizard
+
+    _set_session_state(
+        monkeypatch,
+        llm_provider_label="NVIDIA AI Endpoints",
+        llm_model="meta/llama-3.3-405b-instruct",
+    )
+    options, capable, prov, _model = wizard._resolve_pdf_mode_options()
+    assert options == ["snapshot"]
+    assert capable is False
+    assert prov == "nvidia-ai-endpoints"
+
+
+def test_mode_options_ollama_excluded_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ollama is gated off the LLM extraction tier unless the operator
+    explicitly opts in via the env override (matches
+    ``llm_capabilities`` defaults)."""
+    from scripts.ai_assistant.ui import wizard
+
+    monkeypatch.delenv("REPORTALIN_PDF_LLM_CAPABLE_MODELS", raising=False)
+    _set_session_state(
+        monkeypatch,
+        llm_provider_label="Ollama (local)",
+        llm_model="qwen3:32b",
+    )
+    options, capable, _prov, _model = wizard._resolve_pdf_mode_options()
+    assert options == ["snapshot"]
+    assert capable is False
+
+
+# ── _PDF_MODE_LABELS sanity ─────────────────────────────────────────────────
+
+
+def test_mode_labels_cover_all_modes() -> None:
+    """Every mode the dispatcher accepts has a human-readable label so
+    the wizard's radio doesn't silently render a raw constant."""
+    from scripts.ai_assistant.ui.wizard import _PDF_MODE_LABELS
+
+    assert {"snapshot", "llm"} <= set(_PDF_MODE_LABELS.keys())
+    for label in _PDF_MODE_LABELS.values():
+        assert label and label != ""


### PR DESCRIPTION
## Summary

- Wizard step 2 now surfaces a **PDF extraction source** radio with two choices: *Use existing study data (verified snapshot)* or *Generate fresh PDF extraction (LLM-assisted)*. Closes the integration leg of PR #15.
- Choice flows through ``REPORTALIN_PDF_EXTRACTION_MODE`` (snapshot/llm) injected into the ``main.py --pipeline`` subprocess alongside the existing KeyStore env hand-off — keys never reach the parent process's ``os.environ``.
- ``extract_pdfs_to_jsonl`` dispatches: ``snapshot`` publishes ``initial`` baselines verbatim, ``llm`` delegates per-PDF to ``pdf_pipeline.extract_pdf`` (PR #15's two-way orchestrator), unset preserves the legacy raw-PDF API path so CLI users see no behaviour change.
- Capability gate in ``_resolve_pdf_mode_options()`` requires BOTH ``llm_capabilities.is_capable_model`` AND ``pdf_pipeline.ORCHESTRATOR_SUPPORTED_PROVIDERS`` (anthropic + google). Without the second clause, picking ``llm`` with OpenAI/NVIDIA would silently fall through to snapshot.

## Test plan

- [x] ``tests/test_wizard_pdf_mode.py`` — 10 new tests: mode env propagation through ``run_pipeline()`` (snapshot/llm/unset/garbage), capability+provider gating (capable, non-capable model, OpenAI capable-but-unsupported, NVIDIA capable-but-unsupported, Ollama excluded), label sanity.
- [x] ``tests/test_extract_pdf_data.py`` — 5 new tests: ``snapshot`` publishes baseline verbatim, missing-baseline error, ``llm`` mode delegates with credentials forwarded, unset/unrecognised both fall back to legacy ``_resolve_pdf_provider``.
- [x] Full suite: 918 pass + 3 Linux-skip.
- [x] ruff strict clean across ``scripts/`` + ``tests/``.
- [x] mypy clean on touched files (``wizard.py``, ``extract_pdf_data.py``, ``pdf_pipeline.py``).
- [x] doc-freshness lint passes.
- [x] Live ``ChatAnthropic`` instantiation smoke-tested with the new code path.

## Threat model notes

- The new modes intentionally bypass the legacy two-part PHI-free attestation gate (``REPORTALIN_PDF_PHI_FREE`` + ``authorities/phi_free_pdfs.md``). Justification: the orchestrator path redacts PHI in extracted text *before* any byte leaves the host (no raw PDF bytes ship to the API), and snapshot mode never makes an LLM call. The legacy path remains the CLI default and keeps its gate.
- The ``REPORTALIN_PDF_EXTRACTION_MODE`` env var is sanitised on both sides: wizard normalises to ``llm``/``snapshot`` before injection; dispatcher rejects anything else and falls back to the legacy path. Garbage in session_state can no longer disable the audit gate.