### PR TITLE
chore: bump 0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,10 +494,10 @@ uv run python main.py --version
 
 | Commit Message | Version Bump | Example |
 |----------------|--------------|---------|
-| `fix: ...` | **Patch** | 0.18.0 → 0.18.1 |
-| `feat: ...` | **Minor** | 0.18.0 → 0.19.0 |
-| `feat!: ...` or `BREAKING CHANGE:` | **Major** | 0.18.0 → 1.0.0 |
-| Other (docs, chore, refactor, style, test) | **No bump** | 0.18.0 (unchanged) |
+| `fix: ...` | **Patch** | 0.19.0 → 0.19.1 |
+| `feat: ...` | **Minor** | 0.19.0 → 0.20.0 |
+| `feat!: ...` or `BREAKING CHANGE:` | **Major** | 0.19.0 → 1.0.0 |
+| Other (docs, chore, refactor, style, test) | **No bump** | 0.19.0 (unchanged) |
 
 **Via Git hooks (automatic):** commit normally — the post-commit hook analyses
 the message and bumps the version automatically:
@@ -659,4 +659,4 @@ details.
 
 ---
 
-**Version**: 0.18.0 | **Status**: Beta (Active Development — Single-Study Mode)
+**Version**: 0.19.0 | **Status**: Beta (Active Development — Single-Study Mode)

--- a/__version__.py
+++ b/__version__.py
@@ -28,7 +28,7 @@ __all__ = ["__version__", "__version_info__"]
 # Semantic Versioning normal version: X.Y.Z with no leading zeroes except zero itself.
 _SEMVER_CORE_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
-__version__: str = "0.18.0"
+__version__: str = "0.19.0"
 """Canonical repository version in ``MAJOR.MINOR.PATCH`` form."""
 
 _match = _SEMVER_CORE_RE.fullmatch(__version__)

--- a/docs/sphinx/developer_guide/versioning.rst
+++ b/docs/sphinx/developer_guide/versioning.rst
@@ -15,7 +15,7 @@ The canonical version lives in ``__version__.py`` at the repository root:
 
 .. code-block:: python
 
-   __version__: str = "0.18.0"
+   __version__: str = "0.19.0"
 
 All other modules import from this single source:
 


### PR DESCRIPTION
## Summary

- ``__version__`` bumped 0.18.0 → 0.19.0 to ship the Phase 3 PDF redaction work merged in PRs #15 + #16.

## Test plan

- [x] Doc-freshness lint clean.
- [x] ``tests/test_artifact_versions.py`` (8 tests) passes.