### PR TITLE
chore: bump 0.20.0 + audit residual references after PR #18

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,14 @@ Three extraction legs (dictionary, datasets, PDFs) write into a transient stagin
 **World 2 — AI Assistant** (`scripts/ai_assistant/`):
 LangGraph ReAct agent with 12 tools for querying study data. Never accesses raw data.
 
-**Output structure**: `output/{STUDY_NAME}/trio_bundle/{datasets,pdfs,dictionary,variables.json}`, `audit/{dataset,dictionary,pdfs}_cleanup_report.json` + `audit/phi_scrub_report.json` + `audit/lineage_manifest.json` + `audit/telemetry/events.jsonl`, `agent/{analysis,conversations,snapshots}/`; transient staging sibling: `tmp/{STUDY_NAME}/{datasets,dictionary,pdfs}/` (+ `quarantine/` for rows with missing subject_id).
+**Output structure**: `output/{STUDY_NAME}/trio_bundle/{datasets,pdfs,dictionary,variables.json}`, `audit/{dataset,dictionary,pdfs}_cleanup_report.json` + `audit/phi_scrub_report.json` + `audit/lineage_manifest.json` + `audit/telemetry/events.jsonl`, `agent/{analysis,conversations,restore_points}/`; transient staging sibling: `tmp/{STUDY_NAME}/{datasets,dictionary,pdfs}/` (+ `quarantine/` for rows with missing subject_id).
 
-**Snapshots**: byte-for-byte restore-ready copies of the trio bundle live under `output/{STUDY_NAME}/agent/snapshots/<name>/` — gitignored along with the rest of `output/`. They are the restore target for the "Use Existing Data" wizard path when a fresh pipeline run fails. Entry points: library `scripts.utils.snapshots.{create_snapshot, list_snapshots, restore_snapshot, resolve_snapshot_name, SnapshotError}`, CLI `python -m scripts.utils.snapshots {create,list,restore}`, Makefile `make snapshot [SNAPSHOT=<label>] [FORCE=1]` / `make list-snapshots` / `make restore-study SNAPSHOT=<name>`. UI code must consume this surface, never re-scan the filesystem directly.
+**Two snapshot tiers** (PR #18 split):
+
+1. **Tracked baseline** at `snapshots/{STUDY_NAME}/{datasets,dictionary,pdfs,variables.json}` — version-controlled, maintainer-curated, single per-study cleaned trio bundle. The pipeline's PDF orchestrator reads it as the per-PDF fallback when the LLM tier is unavailable. **LLM is forbidden from reading it** — the LLM read zone is `trio_bundle/` + `agent/` only. Maintainer protocol: see `snapshots/README.md`.
+2. **Operator restore points** at `output/{STUDY_NAME}/agent/restore_points/<name>/` — gitignored, multi-named, agent-writable. Used for crash recovery during dev; never read by the pipeline. Library `scripts.utils.snapshots.{create_snapshot, list_snapshots, restore_snapshot, resolve_snapshot_name, SnapshotError}`, CLI `python -m scripts.utils.snapshots {create,list,restore}`, Makefile `make snapshot [SNAPSHOT=<label>] [FORCE=1]` / `make list-snapshots` / `make restore-study SNAPSHOT=<name>`.
+
+**Wizard step 2 flow** (PR #18 rewrite): two top-level buttons — *Use Existing Study* (skip pipeline; trust the live `trio_bundle/`) and *Load Study* (run the pipeline subprocess; orchestrator falls back to the tracked snapshot baseline per-PDF when the LLM tier is unavailable).
 
 **PHI key**: sidecar at `~/.config/report_ai_portal/phi_key` (resolved via `config.PHI_KEY_PATH`, overridable with `XDG_CONFIG_HOME`). Mode must be `0600`. Missing = hard-fail. Bootstrap via `python -m scripts.security.phi_scrub bootstrap-key`. Key rotation = full re-ingestion.
 

--- a/Makefile
+++ b/Makefile
@@ -111,10 +111,11 @@ help:
 	@printf "  $(C)make chat$(N)             Launch Streamlit web UI (with setup wizard)\n"
 	@printf "  $(C)make build-variables$(N)  Build variables.json from all annotation sources\n"
 	@printf "\n"
-	@printf "$(B)$(G)  Snapshots$(N)  $(Y)(output/{STUDY}/agent/snapshots/ — gitignored)$(N)\n"
-	@printf "  $(C)make snapshot$(N)         Copy output/{STUDY}/trio_bundle/ → agent/snapshots/<ts>/\n"
-	@printf "  $(C)make list-snapshots$(N)   List available snapshots (newest first)\n"
-	@printf "  $(C)make restore-study$(N)    Restore a snapshot back into trio_bundle/ (SNAPSHOT=<name>)\n"
+	@printf "$(B)$(G)  Restore Points$(N)  $(Y)(output/{STUDY}/agent/restore_points/ — gitignored)$(N)\n"
+	@printf "  $(C)make snapshot$(N)         Copy output/{STUDY}/trio_bundle/ → agent/restore_points/<ts>/\n"
+	@printf "  $(C)make list-snapshots$(N)   List available restore points (newest first)\n"
+	@printf "  $(C)make restore-study$(N)    Restore a point back into trio_bundle/ (SNAPSHOT=<name>)\n"
+	@printf "  $(Y)Note: tracked-baseline snapshots/{STUDY}/ is curated by hand — see snapshots/README.md$(N)\n"
 	@printf "\n"
 	@printf "$(B)$(G)  Quality$(N)\n"
 
@@ -233,12 +234,15 @@ build-variables:
 	@printf "$(G)✓ variables.json built$(N)\n"
 
 # ═══════════════════════════════════════════════════════════════════════
-# SNAPSHOTS — trio_bundle backup / restore
+# RESTORE POINTS — trio_bundle backup / restore (gitignored, multi-named)
 # ═══════════════════════════════════════════════════════════════════════
-# SNAPSHOT=<name>   (optional) explicit snapshot name
+# Lands in ``output/{STUDY}/agent/restore_points/`` — DISTINCT from the
+# tracked baseline at ``snapshots/{STUDY}/`` (which is maintainer-curated
+# by hand; see ``snapshots/README.md``).
+# SNAPSHOT=<name>   (optional) explicit restore-point name
 #                   default for snapshot-study: UTC timestamp
 #                   required   for restore-study
-# FORCE=1           allow overwriting an existing snapshot of the same name
+# FORCE=1           allow overwriting an existing restore point of the same name
 
 snapshot-study:
 	@$(PYTHON) -m scripts.utils.snapshots create \

--- a/README.md
+++ b/README.md
@@ -251,11 +251,12 @@ AI Assistant
   make chat                Launch Streamlit web UI
   make chat-cli            Start interactive AI Assistant chat (terminal)
 
-Snapshots — output/{STUDY}/agent/snapshots/ (gitignored, under output/)
-  make snapshot            Copy output/{STUDY}/trio_bundle/ → agent/snapshots/<ts>/
+Restore Points — output/{STUDY}/agent/restore_points/ (gitignored)
+  make snapshot            Copy output/{STUDY}/trio_bundle/ → agent/restore_points/<ts>/
                            SNAPSHOT=<name> for an explicit label; FORCE=1 to overwrite
-  make list-snapshots      List available snapshots (newest first)
-  make restore-study       Restore a snapshot back into trio_bundle/ (SNAPSHOT=<name>)
+  make list-snapshots      List available restore points (newest first)
+  make restore-study       Restore a point back into trio_bundle/ (SNAPSHOT=<name>)
+  Note: tracked-baseline snapshots/{STUDY}/ is curated by hand — see snapshots/README.md
 
 Quality
   make test                Run pytest suite
@@ -494,10 +495,10 @@ uv run python main.py --version
 
 | Commit Message | Version Bump | Example |
 |----------------|--------------|---------|
-| `fix: ...` | **Patch** | 0.19.0 → 0.19.1 |
-| `feat: ...` | **Minor** | 0.19.0 → 0.20.0 |
-| `feat!: ...` or `BREAKING CHANGE:` | **Major** | 0.19.0 → 1.0.0 |
-| Other (docs, chore, refactor, style, test) | **No bump** | 0.19.0 (unchanged) |
+| `fix: ...` | **Patch** | 0.20.0 → 0.20.1 |
+| `feat: ...` | **Minor** | 0.20.0 → 0.21.0 |
+| `feat!: ...` or `BREAKING CHANGE:` | **Major** | 0.20.0 → 1.0.0 |
+| Other (docs, chore, refactor, style, test) | **No bump** | 0.20.0 (unchanged) |
 
 **Via Git hooks (automatic):** commit normally — the post-commit hook analyses
 the message and bumps the version automatically:
@@ -659,4 +660,4 @@ details.
 
 ---
 
-**Version**: 0.19.0 | **Status**: Beta (Active Development — Single-Study Mode)
+**Version**: 0.20.0 | **Status**: Beta (Active Development — Single-Study Mode)

--- a/__version__.py
+++ b/__version__.py
@@ -28,7 +28,7 @@ __all__ = ["__version__", "__version_info__"]
 # Semantic Versioning normal version: X.Y.Z with no leading zeroes except zero itself.
 _SEMVER_CORE_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
-__version__: str = "0.19.0"
+__version__: str = "0.20.0"
 """Canonical repository version in ``MAJOR.MINOR.PATCH`` form."""
 
 _match = _SEMVER_CORE_RE.fullmatch(__version__)

--- a/docs/irb_dossier/phi_walkthrough.md
+++ b/docs/irb_dossier/phi_walkthrough.md
@@ -334,8 +334,15 @@ Yes, load-bearing. `main.py` runs **Step 1.6 PHI scrub** *before* **Step 1.7 dat
 ### Q24. Are older, less-capable LLMs allowed?
 Not remotely. `model_policy.py` maintains a minimum-capability allowlist; remote models below the floor are rejected at load time. Ollama is version-floor-exempt because the operator controls the inference runtime. This prevents accidental use of an older, less-safety-tuned cloud model with study data.
 
-### Q25. Can `step_cache` or `snapshots` let stale PHI-bearing artifacts surface?
-No. `scripts/utils/step_cache.py` records a `.manifest.json` of input SHA-256 + artifact versions; a fresh-cache decision skips re-computation only when every input hash still matches. If any input changed, the step is re-run with the current scrub catalog — so a scrub-rule update cannot be silently bypassed. `scripts/utils/snapshots.py` copies only the **already-scrubbed trio_bundle** into `output/{STUDY}/agent/snapshots/` — restoring a snapshot overwrites the trio with a pre-scrubbed copy, not with raw data. Neither path is a bypass.
+### Q25. Can `step_cache` or restore points / snapshots let stale PHI-bearing artifacts surface?
+No. `scripts/utils/step_cache.py` records a `.manifest.json` of input SHA-256 + artifact versions; a fresh-cache decision skips re-computation only when every input hash still matches. If any input changed, the step is re-run with the current scrub catalog — so a scrub-rule update cannot be silently bypassed.
+
+There are two snapshot tiers (PR #18 split):
+
+1. **Operator restore points** — `scripts/utils/snapshots.py` copies only the **already-scrubbed trio_bundle** into `output/{STUDY}/agent/restore_points/` (gitignored). Restoring overwrites the live trio with a pre-scrubbed copy, never with raw data.
+2. **Tracked baseline** — `snapshots/{STUDY}/` at the repo root holds a maintainer-curated cleaned trio bundle, used by the pipeline's PDF orchestrator as a per-PDF fallback. The LLM is forbidden from reading it (its read zone is `trio_bundle/` + `agent/` only). Maintainer protocol requires the baseline to come from a verified scrubbed run; see `snapshots/README.md`.
+
+Neither path is a bypass.
 
 ### Q26. What stops a researcher from jailbreaking the agent to dump raw data?
 Four compounding controls, any one of which blocks the attack; the attack has to defeat all four.

--- a/docs/sphinx/developer_guide/operations.rst
+++ b/docs/sphinx/developer_guide/operations.rst
@@ -64,7 +64,10 @@ Individual Steps
    * - ``make bundle``
      - Re-assemble the trio bundle from already-scrubbed staging artifacts
    * - ``make snapshot``
-     - Snapshot the current trio bundle into ``output/{STUDY}/agent/snapshots/``
+     - Save a restore point of the current trio bundle to
+       ``output/{STUDY}/agent/restore_points/`` (gitignored). The
+       version-controlled tracked baseline at ``snapshots/{STUDY}/`` is
+       maintainer-curated by hand — see ``snapshots/README.md``.
    * - ``make chat``
      - Launch the Streamlit research-assistant UI (with setup wizard)
    * - ``make chat-cli``

--- a/docs/sphinx/developer_guide/project_status.rst
+++ b/docs/sphinx/developer_guide/project_status.rst
@@ -158,8 +158,9 @@ Utilities
      - ``scripts/utils/telemetry.py``
    * - Step cache (incremental-run manifest + skip semantics)
      - ``scripts/utils/step_cache.py``
-   * - Snapshots (trio-bundle copy/restore library + CLI; live under
-       ``output/{STUDY}/agent/snapshots/``, gitignored)
+   * - Restore points (trio-bundle copy/restore CLI; live under
+       ``output/{STUDY}/agent/restore_points/``, gitignored). Distinct
+       from the version-controlled tracked baseline at ``snapshots/{STUDY}/``.
      - ``scripts/utils/snapshots.py`` + ``python -m scripts.utils.snapshots``
    * - Artifact versioning
      - ``scripts/artifact_versions.py``

--- a/docs/sphinx/developer_guide/versioning.rst
+++ b/docs/sphinx/developer_guide/versioning.rst
@@ -15,7 +15,7 @@ The canonical version lives in ``__version__.py`` at the repository root:
 
 .. code-block:: python
 
-   __version__: str = "0.19.0"
+   __version__: str = "0.20.0"
 
 All other modules import from this single source:
 

--- a/docs/sphinx/user_guide/quickstart.rst
+++ b/docs/sphinx/user_guide/quickstart.rst
@@ -189,12 +189,19 @@ runs::
     make list-snapshots                         # newest first
     make restore-study SNAPSHOT=indovap-2026q1  # overwrites live trio_bundle/
 
-Snapshots live under ``output/{STUDY_NAME}/agent/snapshots/<name>/`` and
-are fully gitignored along with the rest of ``output/``. They are
+Restore points live under ``output/{STUDY_NAME}/agent/restore_points/<name>/``
+and are fully gitignored along with the rest of ``output/``. They are
 byte-for-byte copies of the PHI-scrubbed trio bundle and contain no
-audit logs, telemetry, or conversations. The wizard's "Use Existing
-Data" button and the future "Load existing study data" flow read from
-this tree.
+audit logs, telemetry, or conversations. They support crash-recovery
+during dev (rolling back ``trio_bundle/`` to a prior cohort) and are
+distinct from the version-controlled tracked baseline at
+``snapshots/{STUDY_NAME}/`` (maintainer-curated, used by the pipeline's
+PDF orchestrator as a fallback). See ``snapshots/README.md``.
+
+The wizard's step-2 "Use Existing Study" button skips the pipeline and
+trusts the live ``trio_bundle/``; "Load Study" runs the pipeline (with
+the tracked snapshot baseline as PDF fallback when the LLM tier is
+unavailable).
 
 Next Steps
 ----------

--- a/main.py
+++ b/main.py
@@ -183,10 +183,13 @@ off-limits to the agent.
   read its own prior events structurally, by directory. Hard-rejected by
   `validate_agent_read`.
 - `agent/` — Per-session state. `analysis/` holds deterministic epidemiology
-  outputs, `conversations/` holds chat transcripts, and `snapshots/` holds
-  restore-ready copies of the trio bundle (the "Use Existing Data" restore
-  target). Readable by the LLM agent so it can recall its own prior results
-  and restore the bundle; `analysis/` is also its sandbox write zone (the
+  outputs, `conversations/` holds chat transcripts, and `restore_points/` holds
+  multi-named operator restore copies of the trio bundle (crash-recovery
+  target; gitignored). The version-controlled tracked baseline lives at
+  `snapshots/{study}/` at the repo root and is intentionally OUTSIDE
+  `agent/` — the LLM cannot read it. Readable parts of `agent/` (analysis,
+  conversations, restore_points) feed the agent's own session memory;
+  `analysis/` is also its sandbox write zone (the
   narrower `validate_sandbox_write` — other `agent/` subdirs are read-only
   to LLM-generated code).
 

--- a/scripts/ai_assistant/ui/model_policy.py
+++ b/scripts/ai_assistant/ui/model_policy.py
@@ -146,5 +146,5 @@ def describe_allowlist() -> str:
         "Loading or reloading study data requires a high-capability model: "
         "Claude **Opus ≥ 4.6**, Gemini **Pro ≥ 3.1**, GPT **≥ 5.3**, "
         "or any local **Ollama** model. "
-        "\"Use Existing Data\" is always available regardless of model."
+        "\"Use Existing Study\" is always available regardless of model."
     )

--- a/scripts/extraction/extract_pdf_data.py
+++ b/scripts/extraction/extract_pdf_data.py
@@ -110,8 +110,8 @@ INTER_PDF_DELAY: float = config.PDF_EXTRACTION_INTER_DELAY
 #                     capable-LLM call + snapshot fallback per-PDF when the
 #                     LLM can't handle a form).
 #   2. ``snapshot`` — skip the LLM entirely and publish the human-verified
-#                     baseline JSONs from
-#                     ``output/{STUDY}/agent/snapshots/initial/pdfs/``.
+#                     baseline JSONs from ``snapshots/{STUDY}/pdfs/`` (the
+#                     repo-tracked baseline; LLM-invisible).
 #
 # When :data:`_PDF_EXTRACTION_MODE_ENV` is unset, ``extract_pdfs_to_jsonl``
 # falls back to the legacy raw-PDF API path (gated by the two-part
@@ -795,10 +795,10 @@ def _run_snapshot_mode(
     """Publish the verified baseline JSONs verbatim — no LLM call.
 
     For each annotated PDF, copy the matching
-    ``{stem}_variables.json`` from
-    ``output/{STUDY}/agent/snapshots/initial/pdfs/`` into ``dest_dir``.
-    A missing snapshot is reported as an error (the form will simply be
-    absent from the published bundle); it is NOT a fatal failure.
+    ``{stem}_variables.json`` from ``snapshots/{STUDY}/pdfs/`` (the
+    repo-tracked baseline; LLM-invisible) into ``dest_dir``. A missing
+    snapshot is reported as an error (the form will simply be absent
+    from the published bundle); it is NOT a fatal failure.
     """
     snapshot_dir = _initial_snapshot_pdfs_dir()
     log.info("PDF extraction: snapshot mode — using %s", snapshot_dir)

--- a/scripts/utils/snapshots.py
+++ b/scripts/utils/snapshots.py
@@ -311,7 +311,7 @@ def main(argv: list[str] | None = None) -> int:
 
     p_create = sub.add_parser(
         "create",
-        help="Copy output/{STUDY}/trio_bundle/ → output/{STUDY}/agent/snapshots/<name>/",
+        help="Copy output/{STUDY}/trio_bundle/ → output/{STUDY}/agent/restore_points/<name>/",
     )
     p_create.add_argument(
         "--name",


### PR DESCRIPTION
## Summary

PR #18 split snapshots into two tiers (tracked baseline + operator restore points) and rewrote the wizard step 2 to a two-button flow. This PR sweeps the doc + code surface for stragglers and bumps to 0.20.0.

## Audit findings + fixes

- **Operator surface**: Makefile help text + README + AGENTS.md retitled "Snapshots" section to "Restore Points" with the new gitignored path; tracked baseline at `snapshots/{STUDY}/` documented as the curated-by-hand parallel concept.
- **Code-side stragglers**: `scripts/utils/snapshots.py` argparse help, `scripts/extraction/extract_pdf_data.py` docstring + comment, `main.py` output-signpost docstring, `scripts/ai_assistant/ui/model_policy.py` button-name caption.
- **Bug found mid-audit**: `main.py:189` had `snapshots/{STUDY}/` (uppercase) inside a `str.format()` template — broke 3 `test_main_helpers` tests. Fixed by lowercasing to `{study}` (matching the existing template placeholder).
- **Sphinx + IRB dossier**: `quickstart.rst`, `project_status.rst`, `operations.rst`, `phi_walkthrough.md::Q25` rewritten to reflect the two-tier model.

## Test plan

- [x] 913 pass + 3 Linux-skip
- [x] ruff strict clean
- [x] mypy clean on touched files
- [x] doc-freshness lint passes (`__version__=0.20.0`)
- [x] Live `ChatAnthropic` instantiation ✓
- [x] Audit grep re-run produces zero stragglers