### PR TITLE
docs: close 2 audit misses found on user re-verification

### DIFF
--- a/docs/irb_dossier/executive_summary.md
+++ b/docs/irb_dossier/executive_summary.md
@@ -76,13 +76,21 @@ The architecture documented below answers each of these.
 ## 4. End-to-End Data Flow
 
 ```
-   Raw study data (PHI-bearing)
-   data/raw/{STUDY}/
-       ├─ datasets/            (Excel / CSV)
-       ├─ data_dictionary/     (Excel)
-       └─ annotated_pdfs/      (CRF templates / protocol)
+   Raw study data (PHI-bearing)            Tracked snapshot baseline
+   data/raw/{STUDY}/                       snapshots/{STUDY}/
+       ├─ datasets/                            ├─ datasets/    (LLM-INVISIBLE,
+       ├─ data_dictionary/                     ├─ dictionary/   version-controlled
+       └─ annotated_pdfs/                      ├─ pdfs/         per-PDF fallback
+                 │                              └─ variables.json   for the PDF
+                 │                                                  orchestrator —
+                 │                                                  PR #18.)
                  │
-                 │   (1) Extraction leg reads raw, writes to AMBER staging
+                 │   (1) PARALLEL extraction phase: Dictionary | Datasets | PDFs
+                 │       run on a 3-worker ThreadPoolExecutor (PR #18). The PDF
+                 │       leg uses the two-way orchestrator (PR #15) — pdfplumber
+                 │       code path + redacted-text LLM call merged via _merge,
+                 │       with per-PDF snapshot fallback. No raw PDF bytes leave
+                 │       the host on the orchestrator path.
                  ▼
    Transient staging (PHI-bearing, short-lived)
    tmp/{STUDY}/             (mode 0700, umask 0077;
@@ -90,7 +98,7 @@ The architecture documented below answers each of these.
        ├─ dictionary/
        ├─ pdfs/
        └─ quarantine/
-                 │
+                 │   (join: cleanup chain runs serially after all three legs land)
                  │   (2) PHI scrub runs over staging datasets
                  │       BEFORE any audit artifact is written
                  ▼
@@ -102,8 +110,8 @@ The architecture documented below answers each of these.
    Published trio bundle (PHI-free, durable)
    output/{STUDY}/trio_bundle/
        ├─ datasets/              <-- LLM read zone (1 of 2; the other is `output/{STUDY}/agent/`)
-       ├─ dictionary/
-       ├─ pdfs/
+       ├─ dictionary/                NOTE: snapshots/{STUDY}/ above is intentionally
+       ├─ pdfs/                       OUTSIDE this zone — the LLM cannot read the baseline.
        └─ variables.json
    output/{STUDY}/audit/
        ├─ phi_scrub_report.json
@@ -112,13 +120,19 @@ The architecture documented below answers each of these.
        ├─ pdfs_cleanup_report.json
        └─ lineage_manifest.json
                  │
-                 │   (4) Researcher asks the AI agent a question
+                 │   (4) Researcher asks the AI agent a question. API keys live
+                 │       in an in-memory KeyStore (PR #3); ``os.environ`` does
+                 │       NOT carry them. The pipeline subprocess is the only
+                 │       place the keys ever appear, and only for the duration
+                 │       of the child run.
                  ▼
    AI agent (LLM) queries trio_bundle via structured tools
-                 │
-                 │   (5) Every tool response passes through
-                 │       a PHI gate + a k-anonymity check before
-                 │       reaching the LLM
+                 │   (``run_python_analysis`` runs in an isolated subprocess
+                 │    with RLIMIT_AS / RLIMIT_NPROC / RLIMIT_CPU clamps — PR #2.)
+                 │   (5) Every tool response passes through three gates:
+                 │       PHI regex gate, k-anonymity check (k=5), and
+                 │       l-diversity check (l=2). See
+                 │       scripts/security/kanon_gate.py.
                  ▼
    Answer to the researcher
 ```

--- a/docs/sphinx/user_guide/faq.rst
+++ b/docs/sphinx/user_guide/faq.rst
@@ -83,6 +83,16 @@ It depends on the LLM provider you choose.
   Note: using a hosted provider for PDF extraction also requires setting
   ``REPORTALIN_PDF_PHI_FREE=1`` — see :doc:`configuration`.
 
+  .. note::
+
+     The Streamlit wizard's step 1 routes the pasted key into an
+     in-memory ``KeyStore`` (``scripts/ai_assistant/keystore.py``,
+     PR #3) and scrubs the corresponding ``*_API_KEY`` from
+     ``os.environ`` for the lifetime of the app. Keys are re-injected
+     only into the short-lived pipeline subprocess via
+     ``KeyStore.env_for_subprocess``. CLI users invoking ``main.py``
+     directly use the env var path normally.
+
 Using the Pipeline
 ------------------
 


### PR DESCRIPTION
## Summary

Second-pass verification on the post-PR-#21 state turned up two more items prior sweeps missed.

1. **Executive summary §4 data flow diagram** — PR #20 updated §6 with the new architecture but left the §4 ASCII diagram on its pre-PR-#15/#18 form. Re-drew the diagram to show: tracked snapshot baseline as a sibling input (LLM-invisible), Phase 1 parallel extraction with 3-worker pool, PDF orchestrator step, KeyStore note (keys not in `os.environ`), subprocess+rlimits sandbox note, three gates (PHI + k-anon + l-diversity).
2. **faq.rst API-key examples** — added a note explaining that the wizard routes pasted keys through `KeyStore` and scrubs them from `os.environ`. Mirrors the configuration.rst note added in PR #20.

Three false positives from the original audit subagent (verified in this round; no fix needed):

- `.github/workflows/ci.yml` exists at HEAD (the agent saw a `D .github/workflows/ci.yml` line in the *initial* git status carried over from a prior conversation, and assumed HEAD).
- `phi_architecture.rst:265` trailing parenthetical refers to `config/study_knowledge.yaml`, not snapshots.
- `developer_guide/index.rst:91` text is correct.

## Acknowledged gap not closed in this PR

Wizard step-2 two-button flow (PR #18) was never Playwright-verified. Streamlit `AppTest` smoke broke on `st.iframe` (used by the bridge JS); I removed the smoke test instead of spinning up the Streamlit dev server. Unit tests cover `run_pipeline()` env injection and the (deleted) `_resolve_pdf_mode_options` contract but not the actual rendered button behaviour. Closing this would require booting `make chat` and clicking through with Playwright; out of scope for the doc-alignment PR series.

## Test plan

- [x] ruff strict clean
- [x] doc-freshness lint passes
- [x] No code touched