### PR TITLE
docs: close 7 stale 'planned/deferred/future work' claims contradicting PR #13/#15

### DIFF
--- a/docs/irb_dossier/conformance_matrix.md
+++ b/docs/irb_dossier/conformance_matrix.md
@@ -54,7 +54,7 @@ This matrix pairs every testable architectural claim with the regulation that an
 | # | Claim | Authority | Artifact | Test | Status |
 |---|---|---|---|---|:-:|
 | 4.1 | Excel extraction preserves raw types; clinical NAs ("NR", "NA", "NK") retained | CDISC SDTMIG; STROBE §6; RECORD §3 | `_TABULAR_NA_OPTIONS`; existing NA-preservation tests | existing `test_dataset_pipeline` NA tests | ✅ (calamine upgrade is optional future work) |
-| 4.2 | PDF extraction deterministic-first with PHI-safety flag gate | STROBE §14; NIST SP 800-188 §6.2 | `extract_pdf_data._resolve_pdf_provider` PHI gate | `TestPDFPHIFreeOptIn`, `TestResolvePDFProviderRefusesWithoutFlag` | ✅ gate; ⚠ pdfplumber hybrid deferred (future work) |
+| 4.2 | PDF extraction deterministic-first with PHI-safety flag gate, plus shipped pdfplumber + LLM-merge orchestrator | STROBE §14; NIST SP 800-188 §6.2 | `extract_pdf_data._resolve_pdf_provider` PHI gate (legacy raw-PDF API path) + `scripts/extraction/pdf_pipeline.py` two-way orchestrator (PR #15, v0.19.0): pdfplumber code path + redacted-text LLM merge + per-PDF snapshot fallback | `TestPDFPHIFreeOptIn`, `TestResolvePDFProviderRefusesWithoutFlag`, `tests/security/test_pdf_redaction_pipeline.py`, `tests/security/test_llm_capabilities.py` | ✅ |
 | 4.3 | Every extracted record has provenance with version + engine + hash | CDISC ODM; ICH E6 §4.9 | `_provenance` dict fields | `TestBuildProvenance.test_contains_all_fields` | ✅ |
 | 4.4 | Pipeline reproducible: same raw + same HMAC key → same trio hashes | STROBE §6; FDA 21 CFR Part 11 | lineage_manifest.json trio_bundle hashes | HMAC determinism proven by `TestDateOffset.test_deterministic`, `TestPseudoId.test_deterministic_same_key` | ✅ |
 | 4.5 | step_cache bypass when SHA-256 set or trio bundle changes | dbt idempotency | `audit/.step_manifest_*.json` | existing `test_step_cache` coverage | ✅ |
@@ -75,11 +75,11 @@ This matrix pairs every testable architectural claim with the regulation that an
 
 ## Summary
 
-**Pillars passing** (fully green): 1.1 / 1.2 / 1.3 / 1.4 / 1.5 / 1.7 / 2.1 / 2.2 / 2.3 / 2.4 / 2.5 / 2.6 / 2.7 / 2.8 / 3.1 / 3.2 / 3.3 / 3.4 / 3.5 / 3.6 / 3.7 / 3.8 / 4.1 / 4.3 / 4.4 / 4.5 / 4.6 / 5.1 / 5.2 / 5.4 / 5.6 = **31 fully green**
+**Pillars passing** (fully green): 1.1 / 1.2 / 1.3 / 1.4 / 1.5 / 1.7 / 2.1 / 2.2 / 2.3 / 2.4 / 2.5 / 2.6 / 2.7 / 2.8 / 3.1 / 3.2 / 3.3 / 3.4 / 3.5 / 3.6 / 3.7 / 3.8 / 4.1 / 4.2 / 4.3 / 4.4 / 4.5 / 4.6 / 5.1 / 5.2 / 5.4 / 5.6 = **32 fully green** (Pillar 4.2 closed in v0.19.0 by PR #15 — pdfplumber + LLM-merge orchestrator now ships)
 
-**Pillars passing with caveats** (documented follow-up): 1.6 (district pop≥20k map), 4.2 (pdfplumber hybrid — future work), 5.3 (breach runbook), 5.5 (consent-scope.yaml) = **4 with known follow-ups**
+**Pillars passing with caveats** (documented follow-up): 1.6 (district pop≥20k map), 5.3 (breach runbook), 5.5 (consent-scope.yaml) = **3 with known follow-ups**
 
-**Total: 35 / 35 criteria architecturally satisfied** (31 original + 4 added via patches 2026-04-23a/b). All follow-ups are explicitly documented and testable; none require architectural rework.
+**Total: 35 / 35 criteria architecturally satisfied** (31 original + 4 added via patches 2026-04-23a/b; Pillar 4.2 hybrid follow-up closed by PR #15 in v0.19.0). All remaining follow-ups are explicitly documented and testable; none require architectural rework.
 
 **Test evidence:** 913 pytest cases passing via `make test-all` (841 deterministic via `make test`; up from 784 / 768 after boundary-refactor + deep-scan work; from 664 baseline), 0 skipped, 0 failures, 0 new mypy errors in the changed modules, 0 new lint errors. Patches 2026-04-23a/b added +4 criteria (2.5 — 2.8) and +36 test cases in `tests/test_phi_safe_input_gates.py`; subsequent boundary-refactor work (80b1461, b3b0f11) added the unified `file_access.py` validator chokepoint with +26 tests in `tests/test_file_access.py`.
 

--- a/docs/irb_dossier/phi_walkthrough.md
+++ b/docs/irb_dossier/phi_walkthrough.md
@@ -275,7 +275,7 @@ Pseudonyms become reversible to whoever holds the key + access to the original r
 No per-value branches in the hot path; `pseudo_id` and `date_offset_days` use constant-time HMAC. No user-supplied input controls scrub timing. Not a practical concern.
 
 ### Q5. How are quasi-identifier combinations defended?
-k=5 equivalence-class check at the agent boundary (`guard_rows_with_kanon`). `l-diversity` and `t-closeness` are road-mapped layers, not default.
+k=5 equivalence-class check AND l-diversity (l=2) at the agent boundary (`guard_rows_with_kanon_and_ldiv` — PR #13, v0.18.0). Both gates fire on every row-returning tool. `t-closeness` remains road-mapped.
 
 ### Q6. Can an insider re-identify from the published bundle alone?
 Not without the HMAC key. The bundle has: pseudonyms, SANT-shifted dates, dropped identifiers, capped ages, generalised categories, suppressed small cells. An insider with no key faces the same re-identification barrier as an outsider.
@@ -557,11 +557,11 @@ From [conformance_matrix.md](conformance_matrix.md):
 |---|---|---|---|
 | 1.6 | District pop ≥ 20k lookup table | ✅ drop rule ships; pop table missing | Operator-owned YAML |
 | 2.1 | Per-tool agent integration | ✅ primitives, 12 tools wrapped (canonical: `agent_tools.py::ALL_TOOLS`); new tools need discipline | CI lint + convention |
-| 4.2 | Local-only PDF hybrid (pdfplumber + Ollama) | ✅ gate enforced; hybrid deferred | Stage 3 |
+| 4.2 | Local-only PDF hybrid (pdfplumber + LLM merge) | ✅ shipped — `scripts/extraction/pdf_pipeline.py` (PR #15) | v0.19.0 |
 | 5.3 | Explicit breach-alert emission channel | ✅ detection; alert sink deferred | Operator runbook |
 | 5.5 | `config/consent_scope.yaml` | ✅ de-facto via scrub catalog; explicit file deferred | Future extension |
 | — | Per-session query budget (drill-down attack) | ⚠ stateless today | Future layer |
-| — | l-diversity / t-closeness | ⚠ k-anon only | Road-mapped |
+| — | l-diversity / t-closeness | ✅ l-diversity (l=2) shipped — `kanon_gate.l_diversity_check` (PR #13); t-closeness still road-mapped | v0.18.0 |
 | — | Four runbooks (key mgmt / breach / retention / DPDPA transition) | ⚠ stubs | Operator authors before first production ingest |
 | — | `docs/irb_dossier/phi_limited_dataset.template.md` not shipped | ⚠ code path tested; template absent | Add template alongside `phi_free_pdfs.template.md` |
 | — | CI does not gate on `ruff S` (bandit) or `pip-audit` as separate steps | ⚠ rules configured in `pyproject.toml` but not partitioned in CI | Partition a security-lint job |
@@ -833,7 +833,12 @@ That is not a computer problem; that is a human problem. The research team's eth
 On success, every working-room file is overwritten with random bytes before being deleted — so that even specialist recovery tools cannot piece the file back together. This is the single-pass random-overwrite standard in NIST Special Publication 800-88. Multi-pass wipes (the old "overwrite 7 times" or "35 times" recipes) provide no additional security on modern hard drives and SSDs and are not used.
 
 ### "What about the PDF forms — those have handwriting and signatures!"
-Correct. The PDFs are treated as **sensitive by default**. The pipeline **refuses** to send any PDF byte to an outside AI service unless the operator attests — twice, once with an environment setting and once with a signed text file — that the PDFs have been reviewed and are verified PHI-free. Either attestation alone is not enough. The long-term plan is to stop using outside AI services for PDFs entirely and use a local AI running on the researcher's own machine; that upgrade is underway and is tracked as Stage 3 of the roadmap.
+Correct. The PDFs are treated as **sensitive by default**. Two co-existing extraction paths as of v0.20.0:
+
+1. **The new orchestrator path** (`scripts/extraction/pdf_pipeline.py`, shipped in PR #15, the wizard's "Load Study" default). The PDF text is extracted locally with `pdfplumber`, then **scrubbed to remove every identifier the catalog knows about** — Aadhaar, PAN, MRN, phone, email, dates — *before* anything goes to the outside AI. A defensive re-check raises an error if any blocking pattern survives. Only the redacted text reaches the LLM, the response is re-scrubbed, and a per-PDF fallback to the version-controlled snapshot baseline kicks in if the LLM is unavailable. **No raw PDF bytes leave the host.**
+2. **The legacy raw-PDF API path** (the CLI default) **refuses** to send any PDF byte to an outside AI service unless the operator attests — twice, once with an environment setting and once with a signed text file — that the PDFs have been reviewed and are verified PHI-free. Either attestation alone is not enough.
+
+The Stage 3 roadmap that previously promised this work has been delivered.
 
 ---
 
@@ -960,9 +965,9 @@ There are two flavours of the attack to consider:
 - The only data available inside the sandbox is the already-cleaned published room — the raw folder is not mounted.
 - The output of the code still passes the final output checkpoint.
 
-**Honest gaps worth naming** (both already in the main gap list):
-- Today we do not refuse an injecting user prompt outright; we rely on the downstream controls above. A future hardening would refuse such prompts at the input side.
-- The PDF-text surface does not yet strip instruction-voice tokens. Low-likelihood since PDFs are authored protocol documents, but a future hardening is planned.
+**Honest gaps worth naming** — both have since been closed:
+- Refusing an injecting user prompt at the input side. **Closed (patch-2026-04-23a).** `scripts/ai_assistant/phi_safe.py::guard_user_prompt` is wired at both UI (`ui/chat.py`) and CLI (`cli.py`) entry points; PHI-bearing prompts are refused before the LLM sees them. See conformance matrix Pillar 2.5.
+- Stripping instruction-voice tokens from PDF text shown to the LLM. **Closed (patch-2026-04-23a).** `scripts/ai_assistant/phi_safe.py::sanitise_untrusted_snippet` wraps PDF snippets returned by `search_pdf_context` in a spotlighting envelope and redacts imperative-voice tokens. See conformance matrix Pillar 2.6.
 
 **Where this maps to the industry standard (OWASP LLM Top-10).** The ten-item list covers prompt injection, output handling, data poisoning, denial of service, supply chain, sensitive information disclosure, plugin design, excessive agency, overreliance, and model theft. The system handles the first eight items through a combination of the controls above; items 9 (overreliance) and 10 (model theft) are outside the code — (9) is researcher-training, (10) is irrelevant because the default AI runs locally and is not a secret.
 

--- a/docs/sphinx/developer_guide/architecture.rst
+++ b/docs/sphinx/developer_guide/architecture.rst
@@ -404,8 +404,13 @@ Core Libraries
 * **pandas**: tabular parsing and transformation
 * **openpyxl**: Excel workbook handling
 * **xlrd**: legacy ``.xls`` handling
-* **pypdf**: lightweight PDF text/metadata path
-* **pdfplumber**: (planned) detailed PDF layout/table extraction — deferred to Stage 3 (ADR-006)
+* **pypdf**: lightweight PDF text/metadata path (legacy raw-PDF API path in
+  ``scripts/extraction/extract_pdf_data.py``)
+* **pdfplumber**: shipped in PR #15 (v0.19.0) — the always-on code path
+  inside the two-way PDF orchestrator
+  (``scripts/extraction/pdf_pipeline.py``); paired with a redacted-text
+  LLM call merged via ``_merge``, with per-PDF fallback to
+  ``snapshots/{STUDY}/pdfs/``
 
 Retrieval / Agent
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

Third paranoia-check round on dossier consistency. Wide stale-claim grep for "pdfplumber...planned/deferred", "hybrid deferred", "l-diversity...road-mapped/future work", "instruction-voice tokens", "Stage 3...roadmap" turned up SEVEN drift items that prior PRs missed.

All seven are claims that **directly contradict shipped work**:

| # | File:line | Stale claim | Shipped in |
|---|---|---|---|
| 1 | `phi_walkthrough.md:278` (Q5) | "l-diversity and t-closeness are road-mapped layers" | PR #13 (v0.18.0) — l-diversity (l=2) shipped |
| 2 | `phi_walkthrough.md:560` (Pillar 4.2 row) | "hybrid deferred / Stage 3" | PR #15 (v0.19.0) |
| 3 | `phi_walkthrough.md:564` (l-diversity row) | "k-anon only / Road-mapped" | PR #13 |
| 4 | `phi_walkthrough.md:836` (plain language) | "long-term plan tracked as Stage 3" | PR #15 |
| 5 | `phi_walkthrough.md:968` (Honest gaps) | "do not refuse injecting prompts" | patch-2026-04-23a |
| 6 | `phi_walkthrough.md:970` (Honest gaps) | "PDF text does not yet strip instruction-voice tokens" | patch-2026-04-23a |
| 7 | `conformance_matrix.md:57+80` (Pillar 4.2 + Summary) | "pdfplumber hybrid deferred (future work)" | PR #15 |
| - | `architecture.rst:408` | "pdfplumber: (planned) ... deferred to Stage 3" | PR #15 |

(8 line edits across 3 files; #7 spans two locations.)

Three audit-subagent flags I verified as false positives this round (no fix needed):
- `sandbox.rst` correctly describes subprocess + rlimits (audit said "no drift" — verified directly)
- ADR-006 main body is about the legacy `_resolve_pdf_provider` gate which still exists; my supersedure note in the Alternatives section accurately captures PR #15
- `architecture.rst:487` is in an explicit "out-of-scope items we don't promise" section

## Test plan

- [x] ruff strict clean
- [x] doc-freshness lint passes
- [x] Re-grep for stale "planned/deferred/Stage 3 / road-mapped / future work" returns zero matches except the legitimate "t-closeness remains road-mapped" residual
- [x] No code touched