### PR TITLE
docs: 4th-pass drift fix + Playwright wizard verification

### DIFF
--- a/docs/irb_dossier/phi_walkthrough.md
+++ b/docs/irb_dossier/phi_walkthrough.md
@@ -314,7 +314,7 @@ No tool accepts birthdate as an output field — the column was dropped. The age
 **Two co-existing paths as of v0.20.0:**
 
 - **Two-way orchestrator** (`scripts/extraction/pdf_pipeline.py`, PR #15 — the wizard's "Load Study" button selects this path). The `pdfplumber` code path always runs first; extracted text is PHI-redacted via `phi_patterns.BLOCKING_PATTERNS` BEFORE any byte leaves the host, with a defensive `_assert_no_raw_phi_in_payload` re-check that raises if any blocking pattern survives. The LLM receives only the redacted text. Response is re-scrubbed via `phi_safe.guard_text` and merged with the code candidate. Per-PDF fallback to the version-controlled `snapshots/{STUDY}/pdfs/` baseline when the LLM tier is unavailable. **No raw PDF bytes leave the host.** Idempotent cache keyed on `SHA-256(pdf_bytes || provider || model || phi_scrub.yaml hash)`.
-- **Legacy raw-PDF API path** (`scripts/extraction/extract_pdf_data.py`, the CLI default) is refused unless the operator opts in via two-factor attestation: `REPORTALIN_PDF_PHI_FREE=1` env flag **and** non-empty `authorities/phi_free_pdfs.md` note. Both are enforced at `extract_pdf_data.py:260-331`.
+- **Legacy raw-PDF API path** (`scripts/extraction/extract_pdf_data.py`, the CLI default) is refused unless the operator opts in via two-factor attestation: `REPORTALIN_PDF_PHI_FREE=1` env flag **and** non-empty `authorities/phi_free_pdfs.md` note. Both are enforced inside `_resolve_pdf_provider` (currently `scripts/extraction/extract_pdf_data.py:305-433`; see `_pdf_phi_free_opt_in` and `_pdf_phi_free_authority_present` for the individual checks).
 
 The Stage-3 roadmap that previously planned this work has been delivered.
 

--- a/docs/sphinx/user_guide/configuration.rst
+++ b/docs/sphinx/user_guide/configuration.rst
@@ -150,6 +150,27 @@ against the IRB dossier.
        (:mod:`scripts.security.phi_ner`). Setting this today is a no-op
        because the implementation is a design stub pending prompt
        calibration against the Indo-VAP narrative corpus.
+   * - ``REPORTALIN_PDF_EXTRACTION_MODE``
+     - (unset)
+     - Selects the PDF extraction path inside
+       ``extract_pdfs_to_jsonl``. ``llm`` runs the orchestrator
+       (``scripts/extraction/pdf_pipeline.py``, PR #15) — pdfplumber
+       code path + redacted-text LLM merge + per-PDF snapshot fallback.
+       ``snapshot`` skips the LLM entirely and publishes the
+       ``snapshots/{STUDY}/pdfs/`` baseline verbatim. Unset (the CLI
+       default) keeps the legacy raw-PDF API path with its two-part
+       PHI-free attestation gate. The wizard's "Load Study" button
+       always sets this to ``llm``.
+   * - ``REPORTALIN_PDF_LLM_CAPABLE_MODELS``
+     - (empty)
+     - Comma-separated lowercase model-name prefixes that the PDF
+       orchestrator's capability gate
+       (:func:`scripts.utils.llm_capabilities.is_capable_model`) treats
+       as capable. **Replaces** (not extends) the hardcoded default
+       allowlist (Claude Opus/Sonnet 4.6+, GPT-5+, Gemini 2.5 Pro,
+       Llama 3.3 405B). Operator opt-in for validated local Ollama
+       models — without this override, Ollama is excluded by default
+       regardless of model name.
 
 PHI key (out-of-repo sidecar)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

User pressed for verification a fourth time and asked me to actually Playwright-verify the wizard. Two new drift items + UI verification.

### Drift found this round

1. **`phi_walkthrough.md:317`** — cited `extract_pdf_data.py:260-331` as the PHI-free attestation gate location. Those lines are now docstring text after the PR #16 dispatcher extended the file. The actual gate function `_resolve_pdf_provider` lives at lines 305-433 today.
2. **Two undocumented env vars** in `os.environ.get(...)` calls:
   - `REPORTALIN_PDF_EXTRACTION_MODE` (the wizard's signal to choose the orchestrator path)
   - `REPORTALIN_PDF_LLM_CAPABLE_MODELS` (operator opt-in for Ollama on the PDF orchestrator's capability gate)
   Added both rows to `configuration.rst` PHI-Safety table.

### Drift verified absent (no fix needed)
- All `REPORTALIN_*` env vars in code now have a docs row.
- `phase3_phi_followups.md:170/176/182` line refs are intentional historical audit pointers; the "v0.20.0 closure update" supersedes them.

### Playwright wizard verification (PR #18 surface)

Booted Streamlit on port 8590, drove the browser through:
- **Step 1** — provider selector (Ollama default), model selector (qwen3:8b), Next button. **No PR #16 PDF mode radio anywhere** (correctly removed).
- **Step 2** — confirmed PR #18 contract: two top-level buttons side-by-side (`Use Existing Study` + `Reload Study`), no PDF mode radio, standard Back/Next nav.
- **Click handler** — `Use Existing Study` clicked: 0 console errors, no exception.

Click handler works, layout matches the PR #18 design, the PR #16 radio is gone. The wizard rendered surface matches the spec.

## Test plan

- [x] ruff strict clean
- [x] doc-freshness lint passes
- [x] Streamlit booted + Playwright drove step 1 → step 2 → click `Use Existing Study` → 0 console errors
- [x] No code touched