### PR TITLE
docs: round 5-12 convergence sweep — final remaining drift items

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Status](https://img.shields.io/badge/status-beta-blue.svg)](https://github.com/solomonsjoseph/RePORTaLiN-RAG)
-[![Documentation](https://img.shields.io/badge/docs-sphinx-blue.svg)](https://solomonsjoseph.github.io/RePORTaLiN/)
+[![Status](https://img.shields.io/badge/status-beta-blue.svg)](https://github.com/solomonsjoseph/RePORT-AI-Portal)
+[![Documentation](https://img.shields.io/badge/docs-sphinx-blue.svg)](https://solomonsjoseph.github.io/RePORT-AI-Portal/)
 [![Privacy-Aware](https://img.shields.io/badge/Privacy-Aware-blue.svg)](https://www.hhs.gov/hipaa/index.html)
 [![Multi-Regulation Support](https://img.shields.io/badge/Regulations-IN%20%2F%20US-green.svg)](https://gdpr.eu/)
 
@@ -184,7 +184,7 @@ processed artifacts
 - **Deterministic builds** — `uv` lockfile + `__version__.py` as single source
   of truth.
 
-> 📖 **Learn more**: <https://solomonsjoseph.github.io/RePORTaLiN/>
+> 📖 **Learn more**: <https://solomonsjoseph.github.io/RePORT-AI-Portal/>
 
 ## Quick Start
 
@@ -200,7 +200,7 @@ processed artifacts
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # 2. Clone and navigate
-git clone https://github.com/solomonsjoseph/RePORTaLiN-RAG.git
+git clone https://github.com/solomonsjoseph/RePORT-AI-Portal.git
 cd "RePORT AI Portal"
 
 # 3. Bootstrap the PHI HMAC key (once per machine)
@@ -634,7 +634,7 @@ open _build/html/index.html   # macOS
 xdg-open _build/html/index.html  # Linux
 ```
 
-Online: <https://solomonsjoseph.github.io/RePORTaLiN/>
+Online: <https://solomonsjoseph.github.io/RePORT-AI-Portal/>
 
 ## Contributing
 
@@ -655,8 +655,8 @@ details.
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/solomonsjoseph/RePORTaLiN-RAG/issues)
-- **Documentation**: <https://solomonsjoseph.github.io/RePORTaLiN/>
+- **Issues**: [GitHub Issues](https://github.com/solomonsjoseph/RePORT-AI-Portal/issues)
+- **Documentation**: <https://solomonsjoseph.github.io/RePORT-AI-Portal/>
 
 ---
 

--- a/docs/irb_dossier/conformance_matrix.md
+++ b/docs/irb_dossier/conformance_matrix.md
@@ -69,7 +69,7 @@ This matrix pairs every testable architectural claim with the regulation that an
 | 5.3 | PHI breach detectable + reportable (72h IRB window) | RePORT Protocol; DPDPA §8(6); ICMR §12 | `phi_gate` block events + `phi_scrub` orphan-overflow | `TestPHIGateCheck` emits blocking events | ✅ detection; ⚠ explicit breach-alert emission channel is a follow-up runbook |
 | 5.4 | Every run captures code version + pipeline version | FDA 21 CFR Part 11 §11.10(e); NIST SP 800-188 §7 | `lineage_manifest.json` + per-row `_provenance.pipeline_version` | `TestBuildProvenance.test_contains_all_fields`, `TestEmitLineageManifest` | ✅ |
 | 5.5 | Consent-scope filter: only IEC-approved fields surface | ICMR §4.3; DPDPA §6 | `phi_scrub.yaml` keep_fields + drop_fields catalog | `TestCatalogCoverage.test_clinical_allowlist_keeps_lab_fields`, `test_sex_preserved` | ✅ catalog enforces; ⚠ operator-owned `config/consent_scope.yaml` is a future extension |
-| 5.6 | Zero runtime imports from `scripts/archive/` | technical-debt separation | grep of `scripts/**/*.py` | ✅ trivially satisfied — `scripts/archive/` was removed in commit `30133c9` (clean-slate cleanup); kept as a regression guard so any reintroduction would re-fail the criterion | ✅ |
+| 5.6 | Zero runtime imports from `scripts/archive/` | technical-debt separation | grep of `scripts/**/*.py` | ✅ trivially satisfied — `scripts/archive/` was removed during a clean-slate cleanup before v0.17.0 and the directory does not exist in the current tree (`ls scripts/`); the criterion is kept as a regression guard so any reintroduction would re-fail the check | ✅ |
 
 ---
 
@@ -81,7 +81,7 @@ This matrix pairs every testable architectural claim with the regulation that an
 
 **Total: 35 / 35 criteria architecturally satisfied** (31 original + 4 added via patches 2026-04-23a/b; Pillar 4.2 hybrid follow-up closed by PR #15 in v0.19.0). All remaining follow-ups are explicitly documented and testable; none require architectural rework.
 
-**Test evidence:** 913 pytest cases passing via `make test-all` (841 deterministic via `make test`; up from 784 / 768 after boundary-refactor + deep-scan work; from 664 baseline), 0 skipped, 0 failures, 0 new mypy errors in the changed modules, 0 new lint errors. Patches 2026-04-23a/b added +4 criteria (2.5 — 2.8) and +36 test cases in `tests/test_phi_safe_input_gates.py`; subsequent boundary-refactor work (80b1461, b3b0f11) added the unified `file_access.py` validator chokepoint with +26 tests in `tests/test_file_access.py`.
+**Test evidence:** 913 pytest cases passing via `make test-all` (841 deterministic via `make test`; up from 784 / 768 after boundary-refactor + deep-scan work; from 664 baseline), 0 skipped, 0 failures, 0 new mypy errors in the changed modules, 0 new lint errors. Patches 2026-04-23a/b added +4 criteria (2.5 — 2.8) and +36 test cases in `tests/test_phi_safe_input_gates.py`; subsequent boundary-refactor work added the unified `scripts/ai_assistant/file_access.py` validator chokepoint with +26 tests in `tests/test_file_access.py`.
 
 **Outstanding design items** (out of scope for this dossier, tracked separately):
 

--- a/docs/irb_dossier/phi_walkthrough.md
+++ b/docs/irb_dossier/phi_walkthrough.md
@@ -218,7 +218,7 @@ Each subsection answers: **what is it, what is the background, why this choice, 
 - **Agent-side chokepoint** (`scripts/ai_assistant/file_access.py`, added 2026-04-24):
   - `validate_agent_read(path)` — path must be under `trio_bundle/` ∪ `agent/` (plus the repo-tracked `config/study_knowledge.yaml` read-allowlist).
   - `validate_agent_write(path)` — path must be under `agent/` only.
-  - `validate_sandbox_write(path)` — narrower variant for the `exec_python` sandbox: writes only to `agent/analysis/`. Threat model is LLM-generated code, so the write zone is tighter than agent-tool code. Uses `commonpath` containment (pre-2026-04-24 the sandbox used `str.startswith` and admitted sibling prefixes like `agent/analysis_exfil/` — closed in commit `b3b0f11`).
+  - `validate_sandbox_write(path)` — narrower variant for the `exec_python` sandbox: writes only to `agent/analysis/`. Threat model is LLM-generated code, so the write zone is tighter than agent-tool code. Uses `commonpath` containment so a sibling prefix like `agent/analysis_exfil/` is rejected (an earlier `str.startswith` implementation admitted such prefixes; the boundary-refactor that introduced `file_access.py` closed that gap — verifiable via the `tests/test_file_access.py::test_sibling_prefix_rejected` regression check).
   - `is_agent_readable(path)` — non-raising sentinel variant.
   - All four resolve with `os.path.realpath` (symlink-safe) then verify containment with `os.path.commonpath`. Audit, telemetry, staging, raw, and arbitrary filesystem paths are hard-rejected. Symlinks inside the agent zone that point outside (e.g. `agent/leak → audit/phi_scrub_report.json`) and `..` traversal escapes are both rejected — covered by `tests/test_file_access.py` (26 cases).
 - **Background.** "Capability-style" runtime zone enforcement. Analogous to Rust's lifetime constraints or seccomp — but at the application layer, so it survives even if the underlying OS is permissive.
@@ -331,7 +331,7 @@ The `+` menu in the chat composer shows "Upload file" / "Upload folder" and moun
 Yes. `.github/workflows/ci.yml` runs on every push to `main` / `develop` and every PR to `main`. Matrix: Python 3.11 / 3.12 / 3.13. Two stages — lint (Ruff + mypy; Ruff `S` flake8-bandit rules enabled in `pyproject.toml`) and tests (full pytest suite via `make test-all`, totalling 913 cases). The PHI-critical subset spans 11 dedicated modules (`test_phi_scrub`, `test_phi_gate`, `test_secure_env`, `test_secure_staging`, `test_log_hygiene`, `test_lineage_manifest`, `test_pdf_phi_flag`, `test_pipeline_provenance`, `test_agent_tools_phi_safe`, `test_phi_safe_input_gates`, `test_file_access`) and runs on every PR. A regression fails the build. See [conformance_matrix.md](conformance_matrix.md) for the authoritative test counts.
 
 ### Q22. Is dependency-vulnerability scanning in CI?
-Partial. `pip-audit` is declared in the `dev` optional-deps group but is not a separate gating step in `.github/workflows/ci.yml`. Ruff `S` rules (hardcoded secrets, command injection, weak crypto) are configured in `pyproject.toml:195-220` and will fire during the lint stage, but there is no partitioned "security lint" job. Listed as a gap in §A.7.
+Partial. `pip-audit` is declared in the `dev` optional-deps group but is not a separate gating step in `.github/workflows/ci.yml`. Ruff `S` rules (hardcoded secrets, command injection, weak crypto) are configured in `pyproject.toml:215-241 (the [tool.ruff.lint] section)` and will fire during the lint stage, but there is no partitioned "security lint" job. Listed as a gap in §A.7.
 
 ### Q23. Does the step ordering matter for audit hygiene?
 Yes, load-bearing. `main.py` runs **Step 1.6 PHI scrub** *before* **Step 1.7 dataset cleanup**, which is the step that emits `dataset_cleanup_report.json`. Therefore the cleanup audit records counts of the post-scrub state and has never seen a raw PHI value. This is deliberate: if the order were reversed, the audit report itself would become a PHI-bearing artifact.
@@ -352,7 +352,7 @@ Neither path is a bypass.
 ### Q26. What stops a researcher from jailbreaking the agent to dump raw data?
 Four compounding controls, any one of which blocks the attack; the attack has to defeat all four.
 1. **No tool reads raw.** The agent has 12 tools (enumerated in `scripts/ai_assistant/agent_tools.py::ALL_TOOLS`); every file-reading tool goes through `scripts.ai_assistant.file_access.validate_agent_read`, which rejects anything outside `trio_bundle/ ∪ agent/`. Even a perfectly-jailbroken LLM cannot call a "read `data/raw/…`" tool because no such tool exists, and constructed paths into audit/telemetry/staging raise `ZoneViolationError` at validator time.
-2. **Bounded capability surface.** No shell, no network, no file-write, no `urllib.request`, no arbitrary-path reads. `run_python_analysis` is the only execution surface, and it is AST-sandboxed (see Q28).
+2. **Bounded capability surface.** No shell, no network, no file-write, no `urllib.request`, no arbitrary-path reads. `run_python_analysis` is the only execution surface, and it is OS-isolated in a subprocess with `RLIMIT_AS` / `RLIMIT_NPROC` / `RLIMIT_CPU` clamps and AST guards inside the child (see Q28).
 3. **Output-side PHI gate.** Every tool return passes `@phi_safe_return → phi_gate_check`. Even if the LLM composed an answer echoing a raw identifier, the regex catalog (Aadhaar, PAN, voter, email, phone, etc.) blocks the response.
 4. **k-anon gate on row-level surfaces.** If the LLM tries to extract uniquely-identifying rows, `guard_rows_with_kanon` suppresses classes of size < 5.
 
@@ -422,7 +422,7 @@ Each step writes a hidden manifest `.<step>.manifest.json` with SHA-256 hashes o
 - Triggers on push to `main`/`develop` + PR to `main` (`paths-ignore: docs/**, *.md`).
 - Python matrix `3.11, 3.12, 3.13`.
 - Two sequential jobs: `lint` (Ruff + mypy) → `test` (pytest).
-- Ruff rules include `S` (flake8-bandit) — hardcoded-secret detection, weak crypto lints — configured in `pyproject.toml:195-220`.
+- Ruff rules include `S` (flake8-bandit) — hardcoded-secret detection, weak crypto lints — configured in `pyproject.toml:215-241 (the [tool.ruff.lint] section)`.
 - Test stage runs the full suite (913 cases via `make test-all`); the PHI-critical subset spans 11 dedicated modules and is included on every PR. See [conformance_matrix.md](conformance_matrix.md) §Test evidence for authoritative totals.
 - Notable tests an IRB reviewer should name-check:
   - `test_agent_tools_phi_safe.py::test_every_tool_decorator_is_followed_by_phi_safe_return` — **source-level gate**. Counts `@tool` and `@phi_safe_return` decorations in `agent_tools.py`; any new tool missing the gate fails CI.

--- a/docs/sphinx/developer_guide/contributing.rst
+++ b/docs/sphinx/developer_guide/contributing.rst
@@ -15,14 +15,14 @@ Setting Up Your Development Environment
 
    .. code-block:: bash
 
-      git clone https://github.com/your-username/RePORTaLiN-RAG.git
-      cd RePORTaLiN-RAG
+      git clone https://github.com/your-username/RePORT-AI-Portal.git
+      cd RePORT-AI-Portal
 
 3. **Add the upstream remote:**
 
    .. code-block:: bash
 
-      git remote add upstream https://github.com/solomonsjoseph/RePORTaLiN-RAG.git
+      git remote add upstream https://github.com/solomonsjoseph/RePORT-AI-Portal.git
 
 4. **Install uv (if not already installed):**
 

--- a/docs/sphinx/developer_guide/sandbox.rst
+++ b/docs/sphinx/developer_guide/sandbox.rst
@@ -203,7 +203,7 @@ Total runtime is ~75 s on macOS (subprocess startup is the bottleneck).
 Future Work
 -----------
 
-Out of scope for v0.17.0; tracked for later releases:
+Out of scope for the current release (v0.20.0); tracked for later:
 
 - Convert trio JSONL → parquet so the child loads DataFrames with
   ``mmap`` instead of re-parsing JSON on every call (~80 % of the

--- a/docs/sphinx/user_guide/data_pipeline.rst
+++ b/docs/sphinx/user_guide/data_pipeline.rst
@@ -85,7 +85,7 @@ Discovers and parses all data dictionary and mapping files.
 - **Process:** Auto-discover files, read every sheet, detect multi-table
   boundaries, inject provenance metadata (``__sheet__``, ``__table__``,
   ``__source_file__``), write one JSONL per table into the staging workspace
-- **Command:** ``make extract-dictionary``
+- **Command:** ``make dictionary``
 
 Dataset Extraction
 ~~~~~~~~~~~~~~~~~~
@@ -125,7 +125,7 @@ co-exist as of v0.20.0:
 - **Final output:** ``output/{STUDY}/trio_bundle/pdfs/`` (after publish)
 - **Process:** code-path text extraction → optional redacted-text LLM
   merge → snapshot fallback per-PDF → atomic-write JSON to staging.
-- **Command:** ``make extract-pdf``
+- **Command:** ``make pdf-extract``
 
 See :doc:`../developer_guide/data_extraction_pdfs` for details.
 

--- a/docs/sphinx/user_guide/faq.rst
+++ b/docs/sphinx/user_guide/faq.rst
@@ -50,8 +50,8 @@ How do I install RePORT AI Portal?
    curl -LsSf https://astral.sh/uv/install.sh | sh
 
    # Clone and setup
-   git clone https://github.com/solomonsjoseph/RePORTaLiN-RAG.git
-   cd RePORTaLiN-RAG
+   git clone https://github.com/solomonsjoseph/RePORT-AI-Portal.git
+   cd RePORT-AI-Portal
    make quickstart    # Syncs dependencies and launches the app
 
 Or manually:
@@ -422,7 +422,7 @@ Open an issue on GitHub with:
 Where can I get help?
 ~~~~~~~~~~~~~~~~~~~~~
 
-* **GitHub Issues**: https://github.com/solomonsjoseph/RePORTaLiN-RAG/issues
+* **GitHub Issues**: https://github.com/solomonsjoseph/RePORT-AI-Portal/issues
 
 Performance & Scaling
 ---------------------

--- a/docs/sphinx/user_guide/installation.rst
+++ b/docs/sphinx/user_guide/installation.rst
@@ -32,8 +32,8 @@ Installation Steps
 
 .. code-block:: bash
 
-   git clone https://github.com/solomonsjoseph/RePORTaLiN-RAG.git
-   cd RePORTaLiN-RAG
+   git clone https://github.com/solomonsjoseph/RePORT-AI-Portal.git
+   cd RePORT-AI-Portal
 
 3. Quick Start (Recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/sphinx/user_guide/quickstart.rst
+++ b/docs/sphinx/user_guide/quickstart.rst
@@ -34,8 +34,8 @@ Step 1 — Install ``uv`` and clone the repo
 .. code-block:: bash
 
    curl -LsSf https://astral.sh/uv/install.sh | sh
-   git clone https://github.com/solomonsjoseph/RePORTaLiN-RAG.git
-   cd RePORTaLiN-RAG
+   git clone https://github.com/solomonsjoseph/RePORT-AI-Portal.git
+   cd RePORT-AI-Portal
    uv sync --all-groups
 
 Expected: ``uv sync`` prints a handful of package resolutions and

--- a/snapshots/README.md
+++ b/snapshots/README.md
@@ -6,7 +6,7 @@ with the same layout as the live `output/{STUDY}/trio_bundle/`:
 
 ```
 snapshots/
-└── {STUDY_NAME}/             # e.g. snapshots/IndoVAP/
+└── {STUDY_NAME}/             # e.g. snapshots/Indo-VAP/ — must match config.STUDY_NAME exactly
     ├── datasets/             # *.jsonl scrubbed datasets (PHI already removed)
     ├── dictionary/           # *.json data dictionary
     ├── pdfs/                 # *_variables.json PDF extractions


### PR DESCRIPTION
## Summary

The user asked me to keep iterating until literally nothing's left. This PR closes **9 more drift items across 8 audit lenses** I had not applied in earlier rounds.

## Items fixed (by round)

| Round | Lens | Items |
|---|---|---|
| 5 | Cross-ref accuracy + version anchors + STUDY_NAME literal | 3 — AST-only sandbox phrasing in Q26, `IndoVAP` vs `Indo-VAP` in `snapshots/README`, `v0.17.0` anchor in `sandbox.rst` Future Work |
| 8 | Make target name accuracy | 2 — `make extract-dictionary` → `make dictionary`, `make extract-pdf` → `make pdf-extract` |
| 9 | Commit-SHA citations resolve in git | 3 — `30133c9`, `80b1461`, `b3b0f11` rebased/squashed during v1.0.0→0.16.1 reset; replaced with verifiable artifact references |
| 10 | Repo URL accuracy | 1 multi-file — README + 4 RST + 1 doc URL all said `RePORTaLiN-RAG` (predecessor repo) instead of `RePORT-AI-Portal` (actual repo). Anyone following install would clone the wrong repo. |
| 11 | Line-range citations into pyproject.toml | 1 — Ruff `S` rules cited at lines 195-220 but actually at 224 (within [tool.ruff.lint] block 215-241). Fixed both citations. |

## End-state verification (Round 12)

Twelve drift greps now return zero non-historical matches:

| Lens | Status |
|---|---|
| Stale paths (`agent/snapshots/`, `snapshots/initial/`, `Use Existing Data`) | ✓ clean (2 intentional historical narrative refs preserved) |
| Stale tense (`pdfplumber...planned/deferred`, `hybrid deferred`, `l-diversity...future work`) | ✓ clean |
| Stale repo URL (`RePORTaLiN-RAG`, `RePORTaLiN/`) | ✓ clean |
| Stale make targets | ✓ clean |
| Stage-3 narrative | ✓ clean |
| Test counts (775/703) | ✓ clean (913/841 everywhere) |
| Line ranges into source files | ✓ verified |
| Env vars (all `REPORTALIN_*` documented) | ✓ verified |
| Function/class names cited in docs vs code | ✓ all 16 symbols verified |
| Test file existence (11 PHI modules) | ✓ all 11 exist |
| Commit hashes (must resolve) | ✓ all surviving citations resolve |
| Markdown structure (balanced fences, no broken links) | ✓ clean |

Plus: `ruff check` clean, `doc-freshness` lint clean, `sphinx-build -W` (warnings-as-errors) clean rebuild succeeds.

## Test plan

- [x] ruff strict clean
- [x] doc-freshness lint passes
- [x] Sphinx clean rebuild with `-W` succeeds
- [x] 12-lens drift grep returns zero non-historical matches
- [x] Cited test name `test_sibling_prefix_rejected` verified to exist
- [x] Cited line range `pyproject.toml:215-241` verified to bracket `[tool.ruff.lint]`
- [x] Cited make targets `dictionary` + `pdf-extract` verified in Makefile
- [x] No code touched