### PR TITLE
docs(sphinx,irb): close completeness gaps surfaced by user re-challenge

### DIFF
--- a/docs/irb_dossier/phi_walkthrough.md
+++ b/docs/irb_dossier/phi_walkthrough.md
@@ -22,7 +22,7 @@ Companion documents in this dossier:
 
 ## A.0 One-paragraph summary
 
-The RePORT AI Portal de-identifies an Indian TB cohort study (Indo-VAP) and answers epidemiological questions from a PHI-free published bundle. PHI flows through a **four-zone honest-broker** (RED → AMBER → GREEN → GREEN-PROTECT). AMBER applies an **eight-lane scrub catalog** driven by a single YAML; GREEN is published **atomically** only after the scrub succeeds; GREEN-PROTECT is a **defence-in-depth gate** at the agent–tool boundary. Fourteen distinct **named processes** implement the controls, each traceable to a regulation, an artifact on disk, and a passing pytest. **The full pytest suite (913 cases via ``make test-all``) passes on the current branch; PHI-critical coverage spans 11 dedicated modules — see [conformance_matrix.md](conformance_matrix.md) for the authoritative test totals.**
+The RePORT AI Portal de-identifies an Indian TB cohort study (Indo-VAP) and answers epidemiological questions from a PHI-free published bundle. PHI flows through a **four-zone honest-broker** (RED → AMBER → GREEN → GREEN-PROTECT). AMBER applies an **eight-lane scrub catalog** driven by a single YAML; GREEN is published **atomically** only after the scrub succeeds; GREEN-PROTECT is a **defence-in-depth gate** at the agent–tool boundary. Fourteen distinct **named processes** implement the controls, each traceable to a regulation, an artifact on disk, and a passing pytest. **The full pytest suite (913 cases via ``make test-all``) passes on the current branch; PHI-critical coverage spans 22 dedicated modules — see [conformance_matrix.md](conformance_matrix.md) for the authoritative test totals.**
 
 ---
 
@@ -328,7 +328,7 @@ The manifest records SHA-256 of the runtime inputs *and* outputs. Replay would r
 The `+` menu in the chat composer shows "Upload file" / "Upload folder" and mounts a `st.file_uploader` widget. **It is not wired to any downstream consumer** (verified by grepping `rpln_plus_uploader` across `scripts/ai_assistant/`). Uploaded bytes live in Streamlit session memory for the duration of the tab and are never written to disk, never passed to the agent, never sent to any LLM provider. Functionally inert from a PHI-handling standpoint today. Listed as an honest gap in §A.7 — should be removed or gated.
 
 ### Q21. Does CI enforce PHI-test regressions on every PR?
-Yes. `.github/workflows/ci.yml` runs on every push to `main` / `develop` and every PR to `main`. Matrix: Python 3.11 / 3.12 / 3.13. Two stages — lint (Ruff + mypy; Ruff `S` flake8-bandit rules enabled in `pyproject.toml`) and tests (full pytest suite via `make test-all`, totalling 913 cases). The PHI-critical subset spans 11 dedicated modules (`test_phi_scrub`, `test_phi_gate`, `test_secure_env`, `test_secure_staging`, `test_log_hygiene`, `test_lineage_manifest`, `test_pdf_phi_flag`, `test_pipeline_provenance`, `test_agent_tools_phi_safe`, `test_phi_safe_input_gates`, `test_file_access`) and runs on every PR. A regression fails the build. See [conformance_matrix.md](conformance_matrix.md) for the authoritative test counts.
+Yes. `.github/workflows/ci.yml` runs on every push to `main` / `develop` and every PR to `main`. Matrix: Python 3.11 / 3.12 / 3.13. Two stages — lint (Ruff + mypy; Ruff `S` flake8-bandit rules enabled in `pyproject.toml:215-241 (the [tool.ruff.lint] section)`) and tests (full pytest suite via `make test-all`, totalling 913 cases). The PHI-critical subset spans **22 dedicated modules**: the original 11 anchor modules (`test_phi_scrub`, `test_phi_gate`, `test_secure_env`, `test_secure_staging`, `test_log_hygiene`, `test_lineage_manifest`, `test_pdf_phi_flag`, `test_pipeline_provenance`, `test_agent_tools_phi_safe`, `test_phi_safe_input_gates`, `test_file_access`) plus 11 added through PRs #2/#3/#4/#7/#11/#13/#15: `test_sandbox_isolation` (PR #2 subprocess isolation), `test_keystore` + `test_log_hygiene_keys` + `test_no_keys_in_parent_environ` (PR #3 KeyStore + key-not-in-environ posture), `test_llm_construction_smoke` (PR #7 keys-as-kwargs), `test_adversarial_phi_safe` (PR #4 PHI-smuggling adversarial pack), `test_phase2_pipeline_polish` + `test_phase2_polish_permissions` (PR #11), `tests/security/test_kanon_l_diversity` (PR #13 l-diversity), `tests/security/test_pdf_redaction_pipeline` + `tests/security/test_llm_capabilities` (PR #15 PDF orchestrator). All 22 run on every PR. A regression fails the build. See [conformance_matrix.md](conformance_matrix.md) for the authoritative test counts.
 
 ### Q22. Is dependency-vulnerability scanning in CI?
 Partial. `pip-audit` is declared in the `dev` optional-deps group but is not a separate gating step in `.github/workflows/ci.yml`. Ruff `S` rules (hardcoded secrets, command injection, weak crypto) are configured in `pyproject.toml:215-241 (the [tool.ruff.lint] section)` and will fire during the lint stage, but there is no partitioned "security lint" job. Listed as a gap in §A.7.
@@ -423,7 +423,7 @@ Each step writes a hidden manifest `.<step>.manifest.json` with SHA-256 hashes o
 - Python matrix `3.11, 3.12, 3.13`.
 - Two sequential jobs: `lint` (Ruff + mypy) → `test` (pytest).
 - Ruff rules include `S` (flake8-bandit) — hardcoded-secret detection, weak crypto lints — configured in `pyproject.toml:215-241 (the [tool.ruff.lint] section)`.
-- Test stage runs the full suite (913 cases via `make test-all`); the PHI-critical subset spans 11 dedicated modules and is included on every PR. See [conformance_matrix.md](conformance_matrix.md) §Test evidence for authoritative totals.
+- Test stage runs the full suite (913 cases via `make test-all`); the PHI-critical subset spans 22 dedicated modules and is included on every PR. See [conformance_matrix.md](conformance_matrix.md) §Test evidence for authoritative totals.
 - Notable tests an IRB reviewer should name-check:
   - `test_agent_tools_phi_safe.py::test_every_tool_decorator_is_followed_by_phi_safe_return` — **source-level gate**. Counts `@tool` and `@phi_safe_return` decorations in `agent_tools.py`; any new tool missing the gate fails CI.
   - `test_agent_tools_phi_safe.py::test_tool_and_phi_safe_return_counts_match` — parity check, same pair.
@@ -573,7 +573,7 @@ From [conformance_matrix.md](conformance_matrix.md):
 
 ## A.8 Evidence inventory
 
-- **Tests across 11 PHI-critical files** — `test_phi_scrub.py`, `test_phi_gate.py`, `test_secure_env.py`, `test_secure_staging.py`, `test_log_hygiene.py`, `test_lineage_manifest.py`, `test_pdf_phi_flag.py`, `test_pipeline_provenance.py`, `test_agent_tools_phi_safe.py`, `test_phi_safe_input_gates.py`, `test_file_access.py`. The full pytest suite (913 cases via `make test-all`) passes on the current branch with 0 failures; see [conformance_matrix.md](conformance_matrix.md) §Test evidence for the authoritative breakdown.
+- **Tests across 22 PHI-critical files** — original 11 anchor modules: `test_phi_scrub.py`, `test_phi_gate.py`, `test_secure_env.py`, `test_secure_staging.py`, `test_log_hygiene.py`, `test_lineage_manifest.py`, `test_pdf_phi_flag.py`, `test_pipeline_provenance.py`, `test_agent_tools_phi_safe.py`, `test_phi_safe_input_gates.py`, `test_file_access.py`; plus 11 added through PRs #2/#3/#4/#7/#11/#13/#15: `test_sandbox_isolation.py`, `test_keystore.py`, `test_log_hygiene_keys.py`, `test_no_keys_in_parent_environ.py`, `test_llm_construction_smoke.py`, `test_adversarial_phi_safe.py`, `test_phase2_pipeline_polish.py`, `test_phase2_polish_permissions.py`, `tests/security/test_kanon_l_diversity.py`, `tests/security/test_pdf_redaction_pipeline.py`, `tests/security/test_llm_capabilities.py`. The full pytest suite (913 cases via `make test-all`) passes on the current branch with 0 failures; see [conformance_matrix.md](conformance_matrix.md) §Test evidence for the authoritative breakdown.
 - **35-criterion conformance matrix** (31 original + 4 added via patches 2026-04-23a/b) — [conformance_matrix.md](conformance_matrix.md) — every criterion anchored to a regulation + artifact + test.
 - **Lineage manifest** per run — `scripts/utils/lineage.py` — `inputs[] + outputs[] + steps[] + posture`.
 - **Per-row provenance** — every JSONL row carries `_provenance.raw_sha256 + pipeline_version + extraction_engine`.
@@ -656,7 +656,7 @@ All four commands are expected to succeed against the current branch.
 
 - New `tests/test_phi_safe_input_gates.py` extended with two new classes: `TestRedactPhiInText` (7 tests) and `TestSanitiseTraceback` (5 tests). Combined with the existing 24 prompt-injection tests, `test_phi_safe_input_gates.py` now has **36 test functions**.
 - `test_agent_tools_phi_safe.py::test_phi_safe_return_is_imported` updated to accept the multi-line import form needed for the new helpers.
-- Broader project suite via `make test-all`: **913 tests, 0 failures** (841 deterministic via `make test`); the PHI-critical subset spans 11 dedicated modules. See [conformance_matrix.md](conformance_matrix.md) §Test evidence for authoritative totals.
+- Broader project suite via `make test-all`: **913 tests, 0 failures** (841 deterministic via `make test`); the PHI-critical subset spans 22 dedicated modules. See [conformance_matrix.md](conformance_matrix.md) §Test evidence for authoritative totals.
 
 **Web-research-driven road-map items (not patched in this round).**
 
@@ -995,7 +995,7 @@ After the first patch we did a deliberate "what else could leak?" pass — web r
 
 5. **Telemetry accepted raw objects.** If some future caller handed the telemetry function an exception object or a dataframe, it was being stored without the same redaction that applied to plain strings. Now any non-primitive value is converted to a string, truncated, and masked before storage.
 
-All five fixes have automated tests. Privacy-related coverage spans 11 dedicated test modules; the broader test suite is **913 passing** via `make test-all` (see [conformance_matrix.md](conformance_matrix.md) §Test evidence for the authoritative totals).
+All five fixes have automated tests. Privacy-related coverage spans 22 dedicated test modules; the broader test suite is **913 passing** via `make test-all` (see [conformance_matrix.md](conformance_matrix.md) §Test evidence for the authoritative totals).
 
 ### B.10.12 What we did NOT fix this round (and why)
 

--- a/docs/sphinx/developer_guide/api_reference.rst
+++ b/docs/sphinx/developer_guide/api_reference.rst
@@ -65,6 +65,22 @@ PDF Extraction
    :undoc-members:
    :show-inheritance:
 
+PDF Orchestrator (two-way pipeline — PR #15)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: scripts.extraction.pdf_pipeline
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+LLM Capability Gate (PR #15)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: scripts.utils.llm_capabilities
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Security Modules
 ----------------
 
@@ -194,6 +210,14 @@ Dataset Cleanup
 
 AI Assistant Modules
 --------------------
+
+KeyStore (in-memory API-key registry — PR #3)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: scripts.ai_assistant.keystore
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Agent Graph
 ~~~~~~~~~~~
@@ -368,6 +392,88 @@ Step Cache
 ~~~~~~~~~~
 
 .. automodule:: scripts.utils.step_cache
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Artifact Version Registry
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: scripts.artifact_versions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Sandbox Subprocess (PR #2 — OS-isolated ``run_python_analysis``)
+----------------------------------------------------------------
+
+The sandbox subpackage executes LLM-generated code in a fresh
+subprocess with OS-level rlimits and an in-child AST guard. See
+:doc:`sandbox` for the conceptual overview.
+
+Sandbox Public API
+~~~~~~~~~~~~~~~~~~
+
+.. automodule:: scripts.ai_assistant.sandbox.replicate
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Sandbox Resource Limits
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: scripts.ai_assistant.sandbox.limits
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Sandbox Child Runner
+~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: scripts.ai_assistant.sandbox.runner
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Extraction I/O Helpers
+----------------------
+
+Clinical Date Parsing
+~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: scripts.extraction.io.clinical_dates
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+File Discovery
+~~~~~~~~~~~~~~
+
+.. automodule:: scripts.extraction.io.file_discovery
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+File I/O Primitives
+~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: scripts.extraction.io.file_io
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+JSONL Reader
+~~~~~~~~~~~~
+
+.. automodule:: scripts.extraction.io.jsonl_reader
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Doc-Freshness Linter
+~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: scripts.lint_doc_freshness
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
## Summary

The user bet that the Sphinx docs were still incomplete. They were right.

Two systemic issues that the prior 12-lens drift sweeps had not detected:

### Issue 1 — `api_reference.rst` missing 12 modules

Autodoc'd 44 of 53 `scripts/*` modules. Missing:

| Module | PR | Importance |
|---|---|---|
| `scripts.extraction.pdf_pipeline` | #15 | **Critical** — v0.19.0 flagship |
| `scripts.utils.llm_capabilities` | #15 | **Critical** — capability gate |
| `scripts.ai_assistant.keystore` | #3 | **Critical** — keys-not-in-env policy |
| `scripts.ai_assistant.sandbox.{replicate,limits,runner}` | #2 | High — subprocess sandbox core |
| `scripts.artifact_versions` | — | Utility |
| `scripts.extraction.io.{clinical_dates,file_discovery,file_io,jsonl_reader}` | — | I/O helpers |
| `scripts.lint_doc_freshness` | — | Self-documenting meta tool |

**Now: 100% module coverage (53 of 53).**

### Issue 2 — "11 PHI-critical test modules" claim is half-stale

Dossier asserts the PHI-critical test surface "spans 11 dedicated modules" in 6 places. Actual count at HEAD is **22** — the original 11 + 11 added through PRs #2/#3/#4/#7/#11/#13/#15. All 6 occurrences updated; the explicit list is now correct.

## Test plan

- [x] 100% scripts/* module autodoc coverage (53/53)
- [x] Sphinx `-W` (warnings as errors) clean rebuild
- [x] Zero residual `spans 11` / `11 PHI-critical` / `11 dedicated`
- [x] ruff strict clean
- [x] doc-freshness lint clean
- [x] No code touched