### PR TITLE
docs(sphinx): rewrite 3 high-drift pages from current code state

### DIFF
--- a/docs/sphinx/developer_guide/data_extraction_pdfs.rst
+++ b/docs/sphinx/developer_guide/data_extraction_pdfs.rst
@@ -1,108 +1,187 @@
 PDF Extraction
 ==============
 
-Extracts structured data from annotated PDF case report forms (CRFs) into
-JSONL format.
+Rewritten 2026-04-27 against the v0.20.0 code state. Orchestrator
+(PR #15) is now the primary path; the legacy raw-PDF API path is
+documented as the back-compat fallback.
 
-.. contents:: On this page
-   :local:
-   :depth: 2
+Two co-existing extraction paths
+--------------------------------
 
-Overview
+Annotated CRF PDFs may carry filled-in patient data, signatures, or
+example subject IDs in annotations — they are presumed PHI-bearing.
+The pipeline ships two paths with very different egress postures:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 39 39
+
+   * - Path
+     - Module
+     - Egress posture
+   * - **Orchestrator (default)**
+     - :mod:`scripts.extraction.pdf_pipeline`
+     - **No raw PDF bytes leave the host.** Text is extracted locally
+       via ``pdfplumber``, PHI-redacted in place, then sent to the
+       LLM as redacted text only.
+   * - **Legacy raw-PDF API**
+     - :mod:`scripts.extraction.extract_pdf_data`
+     - **Raw PDF bytes are base64-encoded and shipped to the
+       provider.** Refused unless the operator opts in twice
+       (``REPORTALIN_PDF_PHI_FREE=1`` env flag *plus* a non-empty
+       attestation note at ``authorities/phi_free_pdfs.md``).
+
+The wizard's "Load Study" button selects the orchestrator. The
+legacy path is the CLI default for back-compat.
+
+Dispatch
 --------
 
-PDF extraction reads annotated clinical forms from
-``data/raw/{STUDY_NAME}/annotated_pdfs/`` and writes structured JSONL records
-to ``output/{STUDY_NAME}/trio_bundle/pdfs/``.
+Both paths route through
+:func:`scripts.extraction.extract_pdf_data.extract_pdfs_to_jsonl`,
+which checks the ``REPORTALIN_PDF_EXTRACTION_MODE`` env var:
 
-PDF forms contain clinical field definitions and form structures, **not raw
-patient data**. They are forwarded directly to the Trio bundle.
+* ``llm`` → orchestrator path (the wizard always sets this).
+* ``snapshot`` → publish ``snapshots/{STUDY}/pdfs/`` baseline
+  verbatim, no LLM call.
+* unset (CLI default) → legacy raw-PDF API path with the two-part
+  attestation gate.
 
-Data Flow
----------
+Orchestrator path (PR #15, the default)
+---------------------------------------
 
-.. code-block:: text
+For each PDF, the orchestrator runs:
 
-   data/raw/{STUDY}/annotated_pdfs/*.pdf
-                 │
-                 ▼
-   extract_pdf_data.py  →  output/{STUDY}/trio_bundle/pdfs/
+1. **Code path (always).** ``pdfplumber.open()`` extracts page text +
+   a heuristic candidate via ``_candidate_from_text``.
+2. **Capability + provider gate.**
+   :func:`scripts.utils.llm_capabilities.is_capable_model` enforces a
+   model allowlist (Claude Opus/Sonnet 4.6+, GPT-5+, Gemini 2.5 Pro,
+   Llama 3.3 405B). The default allowlist is hardcoded; operators can
+   override with ``REPORTALIN_PDF_LLM_CAPABLE_MODELS`` (comma-separated
+   prefix list) — for example to validate a local Ollama model.
+   :data:`scripts.extraction.pdf_pipeline.ORCHESTRATOR_SUPPORTED_PROVIDERS`
+   restricts the LLM tier to ``anthropic`` + ``google`` (where the
+   actual client wiring exists).
+3. **Redact-then-call.** Extracted text is scrubbed via
+   ``phi_patterns.BLOCKING_PATTERNS``; a defensive
+   ``_assert_no_raw_phi_in_payload`` re-checks and raises if any
+   blocking pattern survives. Only the redacted text reaches the
+   LLM.
+4. **Merge.** :func:`scripts.extraction.pdf_pipeline._merge`
+   reconciles the LLM response with the code candidate (LLM wins on
+   field-level conflicts; code fills in vars the LLM missed). The
+   LLM response is also re-scrubbed via
+   :func:`scripts.ai_assistant.phi_safe.guard_text` before merge.
+5. **Idempotent cache.** Keyed on
+   ``SHA-256(pdf_bytes || provider || model || phi_scrub.yaml hash)``;
+   stored at ``tmp/{STUDY}/.pdf_cache/`` (mode ``0600``). Editing the
+   PHI scrub config invalidates every cache entry.
+6. **Snapshot fallback (per-PDF).** When any of (capable model,
+   API key, code-path text non-empty, LLM call success) is missing,
+   the orchestrator publishes the version-controlled baseline at
+   ``snapshots/{STUDY}/pdfs/{stem}_variables.json`` instead.
+   **Code-only output is never an acceptable result** — heuristic-only
+   metadata is too unreliable to publish without LLM oversight.
 
-Source
-------
+Output JSON carries an ``extraction_tier`` field
+(``merged`` / ``llm`` / ``snapshot`` / ``empty``) so any reader can
+tell which path produced it.
 
-- **Path:** ``data/raw/{STUDY_NAME}/annotated_pdfs/``
-- **Format:** Annotated PDF forms (CRFs)
-- Auto-discovered — no manual file list needed
+The orchestrator never reads raw inputs other than the PDF file
+itself. It does not touch ``data/raw/{STUDY}/datasets/`` or
+``data/raw/{STUDY}/data_dictionary/``.
 
-Output
-------
+Capability gate details
+-----------------------
 
-- **Path:** ``output/{STUDY_NAME}/trio_bundle/pdfs/``
-- **Format:** One JSONL file per PDF
-- **Deterministic:** ``sort_keys=True, ensure_ascii=False``
+The capability gate is intentionally conservative. As of v0.20.0 the
+default allowlist is:
 
-JSONL Record Schema
--------------------
+* **Anthropic** — ``claude-opus-4-6+``, ``claude-sonnet-4-6+`` (older
+  Sonnet struggles on multi-section CRFs)
+* **OpenAI** — ``gpt-5+`` (GPT-4 family is borderline on complex
+  CRFs)
+* **Google** — ``gemini-2.5-pro+`` (Flash is excluded — good for
+  chat, weaker on table-heavy PDFs)
+* **NVIDIA NIM** — ``meta/llama-3.3-405b-instruct+`` only
 
-Each line represents a field or section extracted from the PDF:
+**Ollama is excluded by default** regardless of model name —
+historically local Ollama models cannot sustain a JSON-schema
+response on a 30-page CRF. Operator opt-in via
+``REPORTALIN_PDF_LLM_CAPABLE_MODELS`` if you've validated a specific
+local model.
+
+Note that the wizard's UI also enforces
+:data:`ORCHESTRATOR_SUPPORTED_PROVIDERS` (anthropic + google),
+which is narrower than the capability allowlist. An OpenAI or NVIDIA
+model passes ``is_capable_model`` but the wizard will not surface
+"Load Study" as an option for it — the underlying
+``_extract_via_llm`` only has client wiring for anthropic + google.
+This prevents a silent fall-through to snapshot.
+
+Legacy raw-PDF API path
+-----------------------
+
+When ``REPORTALIN_PDF_EXTRACTION_MODE`` is unset (CLI default for
+back-compat), :func:`scripts.extraction.extract_pdf_data._resolve_pdf_provider`
+runs a two-part attestation gate:
+
+1. Env flag ``REPORTALIN_PDF_PHI_FREE=1`` set in the runtime env.
+2. Non-empty ``authorities/phi_free_pdfs.md`` operator-signed
+   attestation note (under version control, audit-trail material).
+
+If either is missing, the function raises ``ValueError`` with a
+remediation message listing three alternatives:
+
+a. Flip both attestations if the source PDFs are verified PHI-free
+   (blank CRFs, protocol-only, MOP).
+b. Use ``--pdf-source <path>`` with pre-extracted JSON files (no LLM
+   call).
+c. Skip the PDF leg entirely; the pipeline succeeds without it.
+
+The legacy path then base64-encodes the entire PDF and ships it to
+Anthropic's ``messages.stream`` or Google Gemini's
+``generate_content`` for native PDF-document understanding. No
+redaction is performed on the legacy path — the operator's
+attestation is the safety story.
+
+Output schema (per-form)
+------------------------
+
+Both paths write per-form JSON files at ``tmp/{STUDY}/pdfs/{stem}_variables.json``
+(later atomically promoted to ``trio_bundle/pdfs/``):
 
 .. code-block:: json
 
    {
-     "variable_name": "IS_AGE",
-     "label": "Age at enrollment",
-     "form_name": "Baseline CRF",
-     "section": "Demographics",
-     "field_type": "numeric",
-     "__source_file__": "baseline_form.pdf",
-     "__page__": 2
+     "form_name": "Form 1A - Index Case Screening",
+     "source_pdf": "form_1a_index_screening.pdf",
+     "version": "v1.0",
+     "summary": "<brief>",
+     "extraction_tier": "merged",
+     "variables": {
+       "ABBREVIATION": {
+         "description": "...",
+         "values": {"1": "Yes", "2": "No"},
+         "depends_on": "PARENT_ABBREVIATION_OR_NULL",
+         "condition": "Human-readable activation rule",
+         "section_context": "<text>"
+       }
+     },
+     "sections": {
+       "SECTION_NAME": {
+         "context": "<instruction text>",
+         "variables": ["ABBREV1", "ABBREV2"]
+       }
+     }
    }
 
-Extraction Capabilities
------------------------
+Within-file dedup (case-insensitive collision handling) and
+cross-form dedup run after extraction; both are pure-function helpers
+in :mod:`scripts.extraction.dedup`.
 
-- Text-based extraction for searchable PDFs (pypdf in the legacy
-  raw-PDF API path; pdfplumber in the orchestrator's code path)
-- Form field identification and structure parsing
-- Variable name detection from form labels
-- Section and page tracking for provenance
-
-Two-way PDF Orchestrator (``pdf_pipeline.py``, PR #15)
--------------------------------------------------------
-
-The wizard's "Load Study" button selects this path; CLI users opt in
-via ``REPORTALIN_PDF_EXTRACTION_MODE=llm``. Per PDF:
-
-1. **Code path (always runs).** ``pdfplumber.open()`` extracts text +
-   a heuristic variable candidate.
-2. **Capability + provider gate.**
-   :func:`scripts.utils.llm_capabilities.is_capable_model` enforces a
-   model allowlist (Claude Opus/Sonnet 4.6+, GPT-5+, Gemini 2.5 Pro,
-   Llama 3.3 405B) AND
-   :data:`scripts.extraction.pdf_pipeline.ORCHESTRATOR_SUPPORTED_PROVIDERS`
-   restricts the LLM tier to anthropic + google (where the actual
-   client wiring exists).
-3. **Redact-then-call.** Extracted text is scrubbed via the existing
-   PHI catalog (``phi_patterns.BLOCKING_PATTERNS``); a defensive
-   ``_assert_no_raw_phi_in_payload`` re-checks and raises if any
-   blocking pattern survives. Only the redacted text reaches the LLM.
-4. **Merge.** :func:`scripts.extraction.pdf_pipeline._merge` reconciles
-   the LLM response with the code candidate (LLM wins on field-level
-   conflicts; code fills in vars the LLM missed). The LLM response is
-   also re-scrubbed via :func:`phi_safe.guard_text` before merge.
-5. **Idempotent cache.** Keyed on
-   ``SHA-256(pdf_bytes || provider || model || phi_scrub.yaml hash)``;
-   stored at ``tmp/{STUDY}/.pdf_cache/`` (mode 0600). Editing the PHI
-   scrub config invalidates every cache entry.
-6. **Snapshot fallback per-PDF.** When any of (capable model, API
-   key, code-path text non-empty, LLM call success) is missing, the
-   orchestrator publishes the version-controlled baseline at
-   ``snapshots/{STUDY}/pdfs/{stem}_variables.json`` instead. **Code-only
-   output is never an acceptable result** — heuristic-only metadata is
-   considered too unreliable to publish without LLM oversight.
-
-CLI Usage
+CLI usage
 ---------
 
 .. code-block:: bash
@@ -110,26 +189,63 @@ CLI Usage
    # Via Makefile (recommended)
    make pdf-extract
 
-   # Via Python (direct module entry point)
+   # Via Python (direct module entry point — legacy path)
    uv run python -m scripts.extraction.extract_pdf_data
 
-Downstream Usage
-----------------
+   # Force orchestrator from CLI
+   REPORTALIN_PDF_EXTRACTION_MODE=llm uv run python main.py --pipeline
 
-PDF extractions are consumed by:
+   # Force snapshot mode (no LLM, no API egress)
+   REPORTALIN_PDF_EXTRACTION_MODE=snapshot uv run python main.py --pipeline
 
-1. **Variables reference builder** (``scripts/extraction/build_variables_reference.py``)
-   — merged with the data dictionary to produce ``variables.json``
-2. **Agent tools** (``scripts/ai_assistant/agent_tools.py``) — accessed via structured-data tools
+   # Skip the PDF leg via pre-extracted JSON
+   uv run python main.py --pipeline --pdf-source /path/to/jsons/
 
-Key Files
+Key files
 ---------
 
-- ``scripts/extraction/extract_pdf_data.py`` — main PDF extraction
-- ``config.py`` — ``ANNOTATED_PDFS_DIR``, ``PDF_EXTRACTIONS_DIR``
+* :mod:`scripts.extraction.pdf_pipeline` — the orchestrator (PR #15).
+  Two-way merge, capability gate, idempotent cache, snapshot
+  fallback.
+* :mod:`scripts.extraction.extract_pdf_data` — the legacy raw-PDF
+  API path; also hosts the dispatcher
+  (``extract_pdfs_to_jsonl``).
+* :mod:`scripts.utils.llm_capabilities` — model-name allowlist
+  (``DEFAULT_CAPABLE_MODEL_PREFIXES``,
+  :func:`scripts.utils.llm_capabilities.is_capable_model`).
+* :mod:`scripts.security.phi_patterns` — the BLOCKING_PATTERNS used
+  by the orchestrator's redaction step (and by the agent-output PHI
+  gate).
+* ``config.STUDY_SNAPSHOTS_DIR`` — the tracked baseline location
+  (``snapshots/{STUDY}/``); see
+  :doc:`operations` for the maintenance protocol.
+
+Testing
+-------
+
+PHI-critical tests for this surface:
+
+* ``tests/security/test_pdf_redaction_pipeline.py`` — pre-LLM
+  redaction, post-LLM re-scrub, merge contract, idempotent cache,
+  two-way decision (LLM-merged or snapshot, never code-only).
+* ``tests/security/test_llm_capabilities.py`` — capability allowlist,
+  Ollama-excluded-by-default, env-override semantics.
+* ``tests/test_pdf_phi_flag.py`` — legacy two-part attestation gate.
+* ``tests/test_extract_pdf_data.py`` — dispatcher mode selection.
+
+Downstream usage
+----------------
+
+* :func:`scripts.extraction.build_variables_reference.build_variables_reference`
+  merges PDF extractions with the data dictionary into
+  ``trio_bundle/variables.json`` (the consolidated schema the agent
+  uses to validate variable names).
+* The agent's ``cohort_builder`` and ``query_dataset`` tools read
+  ``variables.json`` plus per-form ``*_variables.json`` to map
+  user-friendly names back to dataset columns.
 
 Licensing
 ---------
 
-PDF extraction uses open-source libraries (pypdf, pdfplumber) with
-permissive licenses. No proprietary PDF tools are required.
+PDF extraction uses open-source libraries (``pypdf``, ``pdfplumber``)
+under permissive licenses. No proprietary PDF tools are required.

--- a/docs/sphinx/user_guide/data_pipeline.rst
+++ b/docs/sphinx/user_guide/data_pipeline.rst
@@ -1,322 +1,318 @@
 Data Pipeline
 =============
 
-RePORT AI Portal processes clinical study data through a **4-tier honest-broker pipeline**
-(see :doc:`../developer_guide/phi_architecture` and
-``docs/irb_dossier/conformance_matrix.md``):
+Rewritten 2026-04-27 against the v0.20.0 code state. This page
+describes what ``python main.py --pipeline`` (or the wizard's "Load
+Study" button) actually does, in operator terms. For the deep
+architecture see :doc:`../developer_guide/architecture` and
+:doc:`../developer_guide/phi_architecture`.
 
-1. **RED — raw extraction** from ``data/raw/{STUDY}/`` (read-only by the extraction leg).
-2. **AMBER — secure staging** in ``tmp/{STUDY}/`` with mode 0700 + umask 0077 +
-   zero-fill teardown; all transformations (extract / scrub / cleanup / propagation)
-   happen here before anything reaches the permanent output surface.
-3. **GREEN — trio bundle** at ``output/{STUDY}/trio_bundle/`` — PHI-free by
-   construction, plus ``audit/lineage_manifest.json`` as the single IRB-review artifact.
-4. **GREEN-PROTECT — agent boundary** — every LLM tool return passes through the
-   regex-first PHI gate + k-anonymity gate before the response reaches the user.
-
-.. contents:: On this page
-   :local:
-   :depth: 2
-
-Pipeline Architecture
----------------------
+Top-Level Flow
+--------------
 
 .. code-block:: text
 
-   data/raw/{STUDY}/                      snapshots/{STUDY}/
-   +-- data_dictionary/    --+            (tracked baseline; LLM-INVISIBLE;
-   +-- datasets/           --+            used by PDF orchestrator fallback)
-   +-- annotated_pdfs/     --+
-            |  Phase 1: PARALLEL extraction (3-worker ThreadPoolExecutor;
-            |  Dictionary | Datasets | PDFs run concurrently — PR #18)
-            v (all three legs write here first; join before cleanup)
-   tmp/{STUDY}/              [transient — removed on success]
-   +-- datasets/
-   +-- dictionary/
-   +-- pdfs/
-   +-- quarantine/           [rows missing subject_id, from phi_scrub]
-            |
-            v phi_scrub → dataset cleanup → propagation → atomic publish
-   output/{STUDY}/trio_bundle/
-   +-- dictionary/
-   +-- datasets/
-   +-- pdfs/
-   output/{STUDY}/audit/              # dataset-only (PHI-bearing leg)
-   +-- phi_scrub_report.json
-   +-- dataset_cleanup_report.json
-            |
-            v
-   Agent: --chat / --web             Phase 2: ReAct agent + 12 tools
+   data/raw/{STUDY}/                          snapshots/{STUDY}/
+   ├── datasets/                              ├── datasets/    (tracked baseline,
+   ├── data_dictionary/                       ├── dictionary/   LLM-INVISIBLE,
+   └── annotated_pdfs/                        ├── pdfs/         per-PDF fallback
+                                              └── variables.json   for the
+                                                                  PDF orchestrator)
+            │
+            │   STEP 0/1/1.5: PARALLEL extraction (3-worker ThreadPoolExecutor — PR #18)
+            │     ├── Dictionary leg → tmp/{STUDY}/dictionary/
+            │     ├── Datasets leg   → tmp/{STUDY}/datasets/
+            │     └── PDFs leg       → tmp/{STUDY}/pdfs/   (orchestrator: pdfplumber
+            │                                              code path + redacted-text
+            │                                              LLM merge + per-PDF
+            │                                              snapshot fallback)
+            │   (join: cleanup chain runs serially after all three legs land)
+            ▼
+   tmp/{STUDY}/   (AMBER zone — mode 0700, umask 0077, optional tmpfs)
+            │
+            │   STEP 1.6: PHI scrub (datasets only — 8-action catalog)
+            │     date jitter (SANT) + HMAC-SHA256 ID pseudonymization +
+            │     drop / cap / generalize / suppress_small_cell / birthdate / keep
+            │     ↓ emits output/{STUDY}/audit/phi_scrub_report.json
+            │
+            │   STEP 1.7: Dataset cleanup (junk removal + duplicate merge)
+            │     ↓ emits output/{STUDY}/audit/dataset_cleanup_report.json
+            │
+            │   STEP 1.8: Cleanup propagation (dataset drops mirror into dict + PDF legs)
+            │     ↓ emits output/{STUDY}/audit/{dictionary,pdfs}_cleanup_report.json
+            ▼
+   STEP 2: Atomic publish (per-leg rename) → output/{STUDY}/trio_bundle/
+            ├── datasets/             ← LLM read zone (1 of 2; the other is
+            ├── dictionary/             output/{STUDY}/agent/)
+            └── pdfs/
+            │
+            │   STEP 3: Build variables.json (variables_reference.py reads
+            │   the published trio_bundle/ — must come AFTER publish)
+            ▼
+   output/{STUDY}/trio_bundle/variables.json
+            │
+            │   STEP 4: Lineage manifest (raw SHA-256 ↔ published SHA-256 pairs +
+            │   PHI-key fingerprint + compliance posture)
+            │     ↓ emits output/{STUDY}/audit/lineage_manifest.json
+            ▼
+   STEP 5: Output signpost (regenerate output/{STUDY}/README.md)
+            │
+            ▼
+   AMBER cleanup: secure_remove_tree(tmp/{STUDY}/) on success
+   (preserved on failure for forensic inspection)
 
-Running the Pipeline
+The agent reads ``output/{STUDY}/trio_bundle/`` (and
+``output/{STUDY}/agent/``) — and **only** those two. Audit, telemetry,
+staging, raw, and the snapshot baseline at ``snapshots/{STUDY}/`` are
+hard-rejected by
+:func:`scripts.ai_assistant.file_access.validate_agent_read`.
+
+Running the pipeline
 --------------------
 
 Full pipeline:
 
 .. code-block:: bash
 
-   make pipeline
+   python main.py --pipeline             # CLI
+   make pipeline                         # Makefile alias
+   make chat                             # Streamlit wizard → click "Load Study"
 
-Individual phases:
-
-.. code-block:: bash
-
-   make dictionary
-   make extract-datasets
-   make pdf-extract
-
-Quick start (sync + full pipeline):
+Selective skip:
 
 .. code-block:: bash
 
-   make quickstart
+   python main.py --pipeline --skip-dictionary  # only datasets + PDFs
+   python main.py --pipeline --skip-datasets    # only dictionary + PDFs
 
-Phase 1: Extract & Promote
---------------------------
+Force re-run (bypass step-cache):
 
-Dictionary Extraction
-~~~~~~~~~~~~~~~~~~~~~
+.. code-block:: bash
 
-Discovers and parses all data dictionary and mapping files.
+   python main.py --pipeline --force
 
-- **Input:** ``data/raw/{STUDY}/data_dictionary/`` (``.xlsx``, ``.xls``, ``.csv``)
-- **Staging output:** ``tmp/{STUDY}/dictionary/``
-- **Final output:** ``output/{STUDY}/trio_bundle/dictionary/`` (after publish)
-- **Process:** Auto-discover files, read every sheet, detect multi-table
-  boundaries, inject provenance metadata (``__sheet__``, ``__table__``,
-  ``__source_file__``), write one JSONL per table into the staging workspace
-- **Command:** ``make dictionary``
+Step-by-step
+------------
 
-Dataset Extraction
-~~~~~~~~~~~~~~~~~~
+Step 0 — Dictionary loading
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Extracts structured data from Excel/CSV datasets into JSONL.
+Reads ``data/raw/{STUDY}/data_dictionary/*.xlsx`` and writes per-file
+``*.json`` files into ``tmp/{STUDY}/dictionary/``. Carries no PHI.
+Implementation: :func:`scripts.extraction.load_dictionary.load_study_dictionary`.
 
-- **Input:** ``data/raw/{STUDY}/datasets/``
-- **Staging output:** ``tmp/{STUDY}/datasets/``
-- **Final output:** ``output/{STUDY}/trio_bundle/datasets/`` (after publish)
-- **Process:** Extraction into the staging workspace; dataset cleanup then runs
-  against staged artifacts (junk removal, duplicate merge) and emits
-  ``output/{STUDY}/audit/dataset_cleanup_report.json``
-- **Command:** ``make extract-datasets``
+Step 1 — Dataset extraction (with hash-based step cache)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-See :doc:`../developer_guide/data_extraction_datasets` for details.
+Walks ``data/raw/{STUDY}/datasets/*.xlsx`` and converts each row to a
+JSON record in ``tmp/{STUDY}/datasets/``. Records that fail validation
+are recorded as "dropped events" so Step 1.8 can mirror them into the
+dictionary + PDF legs.
 
-PDF Extraction
-~~~~~~~~~~~~~~
+Skip semantics: a hash-based manifest at
+``output/{STUDY}/audit/manifests/dataset_processing.json`` records
+``SHA-256`` of every input file; if the hashes are unchanged AND
+``trio_bundle/datasets/`` still has output, this step is skipped.
 
-Extracts variable definitions from annotated CRF PDF forms. Two paths
-co-exist as of v0.20.0:
+Implementation: :func:`scripts.extraction.dataset_pipeline.process_datasets`.
 
-* **Two-way orchestrator** (``scripts/extraction/pdf_pipeline.py``,
-  shipped in PR #15; default for the wizard's Load Study button). The
-  pdfplumber code path always runs first; extracted text is
-  PHI-redacted and sent to a capable LLM (anthropic, google) for a
-  schema-aware merge with the code candidate. The orchestrator falls
-  back to the version-controlled snapshot baseline at
-  ``snapshots/{STUDY}/pdfs/`` per-PDF when the LLM tier is
-  unavailable. No raw PDF bytes leave the host.
-* **Legacy raw-PDF API path** (``scripts/extraction/extract_pdf_data.py``)
-  remains the CLI default and is gated by the two-part
-  ``REPORTALIN_PDF_PHI_FREE`` operator attestation.
+Step 1.5 — PDF preparation (three branches)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **Input:** ``data/raw/{STUDY}/annotated_pdfs/``
-- **Staging output:** ``tmp/{STUDY}/pdfs/``
-- **Final output:** ``output/{STUDY}/trio_bundle/pdfs/`` (after publish)
-- **Process:** code-path text extraction → optional redacted-text LLM
-  merge → snapshot fallback per-PDF → atomic-write JSON to staging.
-- **Command:** ``make pdf-extract``
+The most failure-prone leg, with the most diagnostics:
 
-See :doc:`../developer_guide/data_extraction_pdfs` for details.
+* **--pdf-source <path>** — the operator points at a directory of
+  pre-extracted JSON files (e.g. snapshots from another study run).
+  ``main.py`` runs ``assert_not_raw()`` to confirm the source is not
+  in RED, then atomic-copies each ``*_variables.json`` into
+  ``tmp/{STUDY}/pdfs/``. No LLM call.
+* **Automatic** (no ``--pdf-source``, ``data/raw/{STUDY}/annotated_pdfs/*.pdf``
+  present): :func:`scripts.extraction.extract_pdf_data.extract_pdfs_to_jsonl`
+  dispatches based on ``REPORTALIN_PDF_EXTRACTION_MODE``:
 
-PHI Scrub (Step 1.6) — 8-Action Honest-Broker Catalog
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  - ``llm`` (the wizard's "Load Study" default) — runs the
+    :mod:`scripts.extraction.pdf_pipeline` orchestrator. pdfplumber
+    code path + redacted-text LLM call merged via ``_merge`` + per-PDF
+    fallback to ``snapshots/{STUDY}/pdfs/`` when LLM unavailable.
+  - ``snapshot`` — skip the LLM entirely; publish the snapshot
+    baseline verbatim.
+  - unset (CLI default for back-compat) — legacy raw-PDF API path.
+    Refused unless the operator opts in via ``REPORTALIN_PDF_PHI_FREE=1``
+    *and* a non-empty attestation note at ``authorities/phi_free_pdfs.md``.
 
-Applies a deterministic PHI pass over staged datasets **before** any audit
-output is written — so raw PHI never leaves ``tmp/`` into ``output/``. Eight
-action classes evaluated in strict priority order (first match wins per field).
+* **No PDFs available** — log a detailed diagnostic (missing dir vs
+  empty dir vs all-failed) and continue without a PDF leg. The
+  operator can pass ``--pdf-source`` next time.
 
-- **Input:** ``tmp/{STUDY}/datasets/*.jsonl`` (scrubbed in place)
-- **Audit output:** ``output/{STUDY}/audit/phi_scrub_report.json`` (counts only)
-- **Quarantine:** ``tmp/{STUDY}/quarantine/*.jsonl`` (rows missing ``subject_id``)
-- **Key:** sidecar HMAC-SHA256 key at ``~/.config/report_ai_portal/phi_key``
-  (mode ``0600``, outside the repo). Bootstrap with
-  ``python -m scripts.security.phi_scrub bootstrap-key``.
-- **Catalog:** ``scripts/security/phi_scrub.yaml`` ships ~200
-  Indo-VAP-calibrated rules — 80 keep allowlist + 93 drop + 3 cap + 3
-  generalize + 3 suppress_small_cell + 25 date + 20 id patterns.
+PHI scrub does NOT run on PDFs — the orchestrator path redacts before
+the LLM call, and the legacy gated path attests PHI-free.
 
-**Priority dispatch** (``_scrub_row`` in ``scripts/security/phi_scrub.py``):
+Step 1.6 — PHI scrub (datasets only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. **keep** — allowlist short-circuits every other rule (clinical lab /
-   medication / time-of-day / categorical indicators).
-2. **birthdate** — posture-dependent: ``safe_harbor`` drops the field;
-   ``limited_dataset`` falls through to rule 7 (date jitter) and requires
-   ``authorities/phi_limited_dataset.md``.
-3. **drop** — field removed entirely (names, Aadhaar / ABHA / PAN / voter /
-   passport / DL / ration / ESIC / PM-JAY / Nikshay, contact info, exact
-   geography, system timestamps, narrative / specify / comment fields, staff
-   identifiers, batch / scan metadata).
-4. **cap** — numeric values greater than threshold replaced with label
-   (default age > 89 → ``"90+"``, HIPAA §164.514(b)(2)(i)(C)).
-5. **generalize** — value-level categorical mapping (marital status →
-   Married / Single / Other; facility type → Government / Private / Other).
-6. **suppress_small_cell** — household-contact counts clamped to the
-   configured threshold (default 5, ICMR §11.7 k-anonymity).
-7. **date jitter** — per-subject deterministic SANT offset in
-   ``[-max_jitter_days, +max_jitter_days]``; preserves every intra-subject
-   interval exactly (survival / incidence / person-time analyses unaffected).
-8. **id pseudonymize** — ``HMAC-SHA256(key, id)[:12]`` → ``SUBJ_<12hex>``.
-   Deterministic cross-file linkage preserved; non-reversible without key.
+Operates on ``tmp/{STUDY}/datasets/*.jsonl`` BEFORE Step 1.7 cleanup.
+Eight action classes evaluated in strict priority order:
 
-Scrubbed rows carry ``_phi_scrubbed: "v1"``; sentinel
-``tmp/{STUDY}/.phi_scrub_complete`` prevents accidental double-scrubbing on
-restart. See :doc:`../developer_guide/architecture` for the full module
-contract and ``docs/irb_dossier/conformance_matrix.md`` for the test evidence.
+1. **keep** — pass through (only for confirmed non-PHI columns)
+2. **birthdate** — replace with ``birthyear`` only
+3. **drop** — null out
+4. **cap** — clamp at a quantile
+5. **generalize** — bucket into ranges (e.g. age → age band)
+6. **suppress_small_cell** — null when the cohort cell has < N rows
+7. **date_jitter** — per-subject deterministic SANT date jitter so
+   within-subject visit intervals are preserved but absolute dates
+   are shifted
+8. **hmac_pseudonymize** — replace IDs with
+   ``HMAC-SHA256(key, value)`` truncated; key lives at
+   ``~/.config/report_ai_portal/phi_key`` (mode ``0600``, outside the
+   repo, never committed)
 
-Cleanup Propagation and Publish
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The scrub writes its sanitised JSONL back into ``tmp/{STUDY}/datasets/``
+in place. Audit at ``output/{STUDY}/audit/phi_scrub_report.json``
+contains counts only — no row contents.
 
-After all three extraction legs complete and dataset cleanup has run, the
-pipeline propagates variable-drop decisions across legs and atomically
-publishes staging to ``trio_bundle/``.
+Implementation: :func:`scripts.security.phi_scrub.run_scrub`.
 
-Steps (sequential, executed by ``main.py``):
+Step 1.7 — Dataset cleanup
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. **Propagation** (``cleanup_propagation.run_propagation``):
+Operates on the now-scrubbed staging tree. Removes junk rows, merges
+duplicate records, records every action in
+``output/{STUDY}/audit/dataset_cleanup_report.json``.
 
-   - Reads ``output/{STUDY}/audit/dataset_cleanup_report.json``.
-   - Computes the pruning set: variables removed from datasets that no longer
-     survive in any remaining dataset (case-insensitive; provenance fields
-     such as ``__sheet__``, ``__source_file__`` are excluded).
-   - Rewrites ``tmp/{STUDY}/dictionary/`` JSONL, dropping entries for pruned
-     variables (side-effect only — no audit report, dictionary carries no PHI).
-   - Rewrites ``tmp/{STUDY}/pdfs/`` JSONL, dropping entries for pruned
-     variables (side-effect only — no audit report, PDFs carry no PHI).
+Implementation: :func:`scripts.extraction.dataset_cleanup.clean_trio_datasets`.
 
-2. **Publish** (``_publish_staging``):
-
-   - Iterates the three staging legs (datasets, dictionary, pdfs).
-   - For each leg, attempts an atomic ``os.rename``; falls back to
-     ``shutil.copytree`` when source and destination span filesystems.
-   - ``trio_bundle/`` is fully consistent only after all three legs publish
-     successfully.
-
-3. **Variables reference** (``build_variables_reference``):
-
-   - Runs after publish, reading the now-complete ``trio_bundle/``.
-
-4. **Lineage manifest** (``emit_lineage_manifest`` — Step 4):
-
-   - Walks raw inputs + published trio bundle + audit directory, recording
-     SHA-256 + size + mtime per file, plus per-leg audit-report references
-     and compliance posture.
-   - Emits ``output/{STUDY}/audit/lineage_manifest.json`` — the single
-     regulator-facing evidence artifact pairing every raw input hash with
-     every published trio artifact hash.
-
-5. **Staging cleanup** (``_cleanup_staging``):
-
-   - **Securely** removes ``tmp/{STUDY}/`` on success — each staging file
-     is overwritten with random bytes and fsynced before unlink to resist
-     filesystem forensics.
-   - On failure, ``tmp/{STUDY}/`` is **left in place** for operator inspection
-     before the next run.
-
-**Audit report schema** (all three reports share the same envelope):
-
-.. code-block:: json
-
-   {
-     "study": "STUDY_NAME",
-     "generated_utc": "2024-01-01T00:00:00Z",
-     "leg": "datasets",
-     "removed": [
-       {
-         "scope": "column",
-         "name": "VAR_X",
-         "file": "source_dataset.jsonl",
-         "sheet": "Sheet1",
-         "reason": "junk_column",
-         "kept": false
-       }
-     ]
-   }
-
-The ``leg`` field is one of ``"datasets"``, ``"dictionary"``, or ``"pdfs"``.
-
-Phase 2: Agent (Query-Time)
-----------------------------
-
-At query time, the ReAct agent uses 12 structured-data tools to answer
-questions directly from the trio bundle. No chunking, embedding, or
-vector index is needed. The canonical list lives in
-:data:`scripts.ai_assistant.agent_tools.ALL_TOOLS`.
-
-- **Tools:** ``search_variables``, ``find_variable_candidates``,
-  ``get_variable_details``, ``list_forms``, ``get_form_variables``,
-  ``query_dataset``, ``get_dataset_stats``, ``get_study_overview``,
-  ``run_python_analysis``, ``cross_reference_variables``,
-  ``run_study_analysis``, ``search_pdf_context``
-- **Code runner:** Sandboxed Python runner with pandas, numpy, scipy, statsmodels,
-  matplotlib
-- **Interfaces:** CLI (``--chat``) and Streamlit web UI (``--web``)
-
-PDF Extraction PHI-Safety Gate
+Step 1.8 — Cleanup propagation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-External-API PDF extraction (Anthropic Claude / Google Gemini) is treated as
-a network egress of PHI by default. ``scripts/extraction/extract_pdf_data.py``
-refuses to initialise an external client unless the operator explicitly
-sets ``REPORTALIN_PDF_PHI_FREE=1`` attesting the source PDFs are PHI-free
-(blank CRFs, protocol, MOP, annotation-only pages). Remediation paths:
+Whatever variables Step 1.7 dropped get mirrored into the dictionary
+leg and the PDF leg in staging. Keeps the published trio bundle
+internally consistent — no dictionary entry or PDF form variable
+referencing a column that was dropped from the dataset.
 
-- Set ``REPORTALIN_PDF_PHI_FREE=1`` (your signed assertion for the IRB).
-- Use pre-extracted PHI-free JSON via ``--pdf-source <path>`` (no LLM call).
-- Skip the PDF leg entirely — the pipeline succeeds without it.
+Implementation: :func:`scripts.extraction.cleanup_propagation.run_propagation`.
 
-Runtime Invariants
+Step 2 — Publish (atomic per-leg rename)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For each leg:
+
+1. Call :func:`scripts.security.secure_env.assert_output_zone` — the
+   destination MUST be under ``output/{STUDY}/``.
+2. If the existing ``trio_bundle/<leg>/`` exists,
+   :func:`scripts.utils.secure_staging.secure_remove_tree` (zero-fill
+   + ``fsync`` + unlink). Republishing must not leave forensically
+   recoverable old bytes.
+3. **Atomic rename** ``staging_dir`` → ``trio_dir``. Same-filesystem
+   = a single inode swap. Cross-filesystem (e.g. tmpfs staging + disk
+   trio) falls back to ``shutil.copytree`` + ``shutil.rmtree``.
+4. Empty staging legs leave the existing trio leg untouched.
+
+Step 3 — Build variables.json
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Walks the published ``trio_bundle/`` and produces
+``trio_bundle/variables.json`` — the consolidated variable schema the
+agent's ``cohort_builder`` uses to validate variable names in
+queries. **Must run after Step 2** because it scans the *published*
+tree, not staging.
+
+Implementation:
+:func:`scripts.extraction.build_variables_reference.build_variables_reference`.
+
+Step 4 — Lineage manifest
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pairs the SHA-256 of every raw input with the SHA-256 of every
+published artifact, plus the PHI-scrub posture, plus a SHA-256
+fingerprint of the HMAC PHI key. **The single artifact an IRB / IEC
+reviewer reads to verify the entire raw → scrub → publish chain
+without seeing any patient data.**
+
+Output: ``output/{STUDY}/audit/lineage_manifest.json``.
+
+Step 5 — Output signpost + secure cleanup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Re-emits a plain-English ``output/{STUDY}/README.md`` describing the
+layout for someone who opens the directory cold (sysadmin, auditor,
+future maintainer). Then runs ``secure_remove_tree`` over the AMBER
+``tmp/{STUDY}/`` workspace. **If any earlier step exited non-zero,
+this cleanup is skipped on purpose** so staging is preserved for
+forensic inspection.
+
+Output structure on success
+---------------------------
+
+.. code-block:: text
+
+   data/raw/{STUDY}/      # untouched (RED)
+   tmp/{STUDY}/           # gone (securely deleted)
+   output/{STUDY}/
+   ├── trio_bundle/                      # GREEN — LLM read zone
+   │   ├── datasets/*.jsonl              # PHI-scrubbed
+   │   ├── dictionary/*.json
+   │   ├── pdfs/*_variables.json         # tier: merged | snapshot | empty
+   │   └── variables.json                # consolidated schema
+   ├── audit/                            # GREEN-PROTECT — counts only
+   │   ├── lineage_manifest.json
+   │   ├── phi_scrub_report.json
+   │   ├── dataset_cleanup_report.json
+   │   ├── dictionary_cleanup_report.json
+   │   ├── pdfs_cleanup_report.json
+   │   └── telemetry/events.jsonl
+   ├── agent/                            # agent-owned operational state
+   │   ├── analysis/                     # generated .py + outputs
+   │   ├── conversations/
+   │   └── restore_points/               # gitignored multi-named bundle copies
+   └── README.md                         # output signpost
+
+Plus the version-controlled tracked baseline at
+``snapshots/{STUDY}/`` (LLM-invisible — not under ``output/``, not
+inside any LLM-readable zone) that the orchestrator's per-PDF
+fallback reads.
+
+The audit envelope
 ------------------
 
-These hold at every pipeline boundary:
+The ``output/{STUDY}/audit/`` tree is the single point of contact
+between the runtime and the IRB-reviewer-facing world. Properties:
 
-1. **Zone guards** enforce the four-tier boundary: raw → AMBER staging → GREEN
-   trio bundle → GREEN-PROTECT agent. Pipeline-side guards
-   (``scripts/security/secure_env.py``: ``assert_not_raw``, ``assert_write_zone``,
-   ``assert_output_zone``, ``assert_trio_bundle_zone``) apply at ingest,
-   staging, and publish. Agent-side guards
-   (``scripts/ai_assistant/file_access.py``: ``validate_agent_read``,
-   ``validate_agent_write``, ``validate_sandbox_write``) apply at every
-   tool-code file read or write. Both layers use ``os.path.realpath`` +
-   ``os.path.commonpath`` containment so symlinks and ``..`` traversal
-   cannot escape. Violations raise ``ZoneViolationError`` (a
-   ``PermissionError`` subclass).
-2. **PHI scrub runs before any audit emission** so the dataset cleanup and
-   propagation audits never contain raw subject IDs or raw dates.
-3. **Every agent tool return passes through ``phi_gate_check``** — blocking
-   findings trigger a redaction message rather than leaking raw PHI tokens.
-4. **k-anonymity ≥ 5** is enforced on row-level responses via
-   ``scripts/security/kanon_gate.py`` — equivalence classes smaller than the
-   threshold suppress to ``"<5"``.
-5. **Per-run integrity chain** — every raw input hashed to SHA-256; the hash
-   rides in every row's ``_provenance`` + the lineage manifest.
-6. **Log PHI hygiene** — ``scripts/utils/log_hygiene.install_phi_redactor``
-   redacts subject IDs + Aadhaar / PAN / phone / email / pincode / SSN / dates
-   from every log record before emit.
+* **Counts-only.** No row contents, no before/after pairs, no subject
+  identifiers. Every report file records aggregate counts and per-rule
+  applications.
+* **LLM-invisible.** ``validate_agent_read`` rejects any path under
+  ``audit/``.
+* **Hash-anchored.**
+  ``output/{STUDY}/audit/lineage_manifest.json`` cryptographically
+  links every raw input to every published artifact.
 
-Step Cache
-----------
+Failure semantics
+-----------------
 
-Each pipeline step is cached. Re-running a step with unchanged inputs
-is a no-op. To force re-execution:
+* Any extraction-leg crash that is NOT the PDF leg fails the run
+  immediately (``sys.exit(1)``). Cleanup chain doesn't run; AMBER
+  staging is preserved.
+* PDF leg crash is logged at WARNING and the run proceeds without
+  PDF outputs. The detailed log line names the failure mode (missing
+  source dir, empty dir, all-files-failed with per-file errors,
+  exception trace).
+* PHI scrub failure (e.g., missing key, malformed YAML config)
+  fails the run immediately.
+* Publish step assertion failure (e.g., misconfigured destination
+  outside ``output/``) fails immediately.
+* On any non-zero exit, AMBER staging at ``tmp/{STUDY}/`` is
+  preserved — operator inspects, fixes, re-runs.
 
-.. code-block:: bash
+Where To Go Next
+----------------
 
-   make clean    # Remove all outputs
-   make pipeline # Full re-run
-
-Next Steps
-----------
-
-- :doc:`configuration` for environment and config settings
-- :doc:`../developer_guide/operations` for operational runbook
+* :doc:`../developer_guide/architecture` — full system architecture.
+* :doc:`../developer_guide/data_extraction_pdfs` — deep dive on the
+  PDF orchestrator (PR #15).
+* :doc:`configuration` — env flags, including
+  ``REPORTALIN_PDF_EXTRACTION_MODE`` and the PHI-safety three.
+* :doc:`../developer_guide/operations` — operational playbook,
+  including the snapshot-baseline maintenance protocol.
+* ``docs/irb_dossier/phi_walkthrough.md`` (outside the Sphinx tree)
+  — the IRB-grade walkthrough with regulatory mapping.

--- a/docs/sphinx/user_guide/overview.rst
+++ b/docs/sphinx/user_guide/overview.rst
@@ -1,136 +1,238 @@
 Overview
 ========
 
+Rewritten 2026-04-27 against the v0.20.0 code state. This page replaces
+an older draft that pre-dated PR #15 (PDF orchestrator) and PR #18
+(parallel extraction + tracked-baseline snapshot tier).
+
 The Pain
 --------
 
-Clinical-research teams at Indian sites wait **weeks to months** every time
-they need a variable pulled from their own study data. The path looks like
-this:
+Clinical-research teams at Indian sites wait **weeks to months** every
+time they need a variable pulled from their own study data. The path
+looks like this:
 
-1. Researcher drafts a request ("give me the smoking-status column joined
-   to the TB-recurrence outcome for Cohort A").
+1. Researcher drafts a request ("give me the smoking-status column
+   joined to the TB-recurrence outcome for Cohort A").
 2. Email goes to the data manager.
 3. Data manager queues the request behind dozens of others.
 4. Extraction happens, tables are mailed back as Excel.
 5. Researcher discovers they need one more column. Goto 1.
 
-Each round-trip is an IRB-sensitive access — the raw data carries PHI and
-cannot simply be copied to researcher laptops. So the queue is long by
-design, not by accident.
+Each round-trip is an IRB-sensitive access — the raw data carries PHI
+and cannot simply be copied to researcher laptops. So the queue is
+long *by design*, not by accident.
 
 The cost compounds: a cohort-level question that *should* take an hour
-(fit a model, generate a plot, write a sentence) takes a calendar month.
-Grants slip. Papers stall. Junior researchers give up.
+(fit a model, generate a plot, write a sentence) takes a calendar
+month. Grants slip. Papers stall. Junior researchers give up.
 
 What RePORT AI Portal Is
 ------------------------
 
-**What.** A single-study, privacy-first, local-first AI assistant that
-answers the researcher's questions directly from the published study
-artifacts — without the data-manager round-trip and without ever exposing
-raw PHI to the LLM.
+A single-study, privacy-first, local-first AI assistant that answers
+the researcher's questions directly from the published study artifacts
+— without the data-manager round-trip and without ever exposing raw
+PHI to the LLM.
 
 **Why.** Researchers own epidemiological-question formulation and
-interpretation; data managers own data-custody. The assistant covers the
-mechanical bit in the middle (fetch the column, run the model, render the
-plot) so the human-expert hours on both sides go to the work only humans
-can do.
+interpretation; data managers own data-custody. The assistant covers
+the mechanical bit in the middle (fetch the column, run the model,
+render the plot) so the human-expert hours on both sides go to the
+work only humans can do.
 
-**How.** A four-tier honest-broker pipeline ingests raw study data once,
-strips PHI into a PHI-free "trio bundle", and stands up a ReAct agent that
-can query the bundle directly. The researcher talks to the agent; the
-agent touches only the de-identified bundle; the raw data stays in the
-locked room.
+**How.** A four-zone honest-broker pipeline ingests raw study data
+once, strips PHI into a PHI-free "trio bundle", and stands up a ReAct
+agent that can query the bundle directly. The researcher talks to the
+agent; the agent touches only the de-identified bundle; the raw data
+stays in the locked room.
+
+The Four Zones
+--------------
+
+Every artifact this project produces lives in exactly one of four
+zones. Confusing them is the failure mode every guard in the codebase
+exists to prevent.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 14 30 56
+
+   * - Zone
+     - Path
+     - Posture
+   * - **RED**
+     - ``data/raw/{STUDY}/``
+     - Raw clinical inputs (Excel datasets, dictionary, annotated
+       PDFs). Presumed to carry PHI. The agent and the LLM never read
+       from here. The extraction subprocess is the only legitimate
+       reader.
+   * - **AMBER**
+     - ``tmp/{STUDY}/``
+     - Per-run scratch workspace. Mode ``0700`` under umask ``0077``.
+       Optionally redirected to ``/dev/shm`` (tmpfs) on Linux via
+       ``REPORTALIN_TMPFS_STAGING=1`` so raw extracted rows never hit
+       physical disk on the extraction host. Securely overwritten +
+       ``fsync``-ed + unlinked on a successful run; preserved on
+       failure for forensic inspection.
+   * - **GREEN**
+     - ``output/{STUDY}/trio_bundle/``
+     - The published, sanitised study bundle: ``datasets/``,
+       ``dictionary/``, ``pdfs/``, ``variables.json``. Every byte has
+       been through PHI scrub + cleanup + propagation + atomic
+       publish. Together with ``output/{STUDY}/agent/`` this forms
+       the LLM agent's read surface (``trio_bundle/`` ∪ ``agent/``).
+   * - **GREEN-PROTECT**
+     - ``output/{STUDY}/audit/``
+     - Counts-only IRB audit envelope: lineage manifest, scrub report,
+       cleanup report, telemetry. Same ``output/`` tree as GREEN but
+       intentionally not part of ``trio_bundle/``. The LLM is
+       hard-rejected here — that's the entire reason audit isn't in
+       trio_bundle.
+
+There is also a fifth, **out-of-zone** location at the repo root:
+``snapshots/{STUDY}/`` holds a version-controlled, maintainer-curated
+*snapshot baseline* of a cleaned trio bundle. The pipeline's PDF
+orchestrator reads this baseline as a per-PDF fallback when the LLM
+tier is unavailable. **The LLM cannot read it** — its read zone is
+strictly ``trio_bundle/`` + ``agent/``, so a stale baseline can never
+be served as live data. See :doc:`../developer_guide/operations` for
+the maintenance protocol.
+
+The Two-Way PDF Orchestrator
+----------------------------
+
+PDF extraction is a special case because annotated CRF PDFs may carry
+filled-in patient data, handwritten signatures, or example subject IDs
+in annotations. The pipeline ships two co-existing paths:
+
+* **Orchestrator path** (``scripts/extraction/pdf_pipeline.py``,
+  shipped in PR #15, the wizard's "Load Study" default). The
+  ``pdfplumber`` code path always runs first and extracts text
+  locally. The text is PHI-redacted via ``phi_patterns.BLOCKING_PATTERNS``
+  *before* any byte leaves the host. A defensive
+  ``_assert_no_raw_phi_in_payload`` re-check raises if any blocking
+  pattern survives. Only the redacted text reaches the LLM. The
+  response is re-scrubbed and merged with the code candidate. Per-PDF
+  fallback to the snapshot baseline at ``snapshots/{STUDY}/pdfs/``
+  when the LLM tier is unavailable. **No raw PDF bytes leave the
+  host on this path.**
+
+* **Legacy raw-PDF API path** (``scripts/extraction/extract_pdf_data.py``,
+  the CLI default for back-compat). Refused unless the operator
+  attests, twice, that the source PDFs are PHI-free: env flag
+  ``REPORTALIN_PDF_PHI_FREE=1`` *and* a non-empty attestation note
+  at ``authorities/phi_free_pdfs.md``.
+
+The Agent Side
+--------------
+
+Once the trio bundle is published, the user is in chat. The LLM agent
+(LangGraph ReAct pattern, provider-agnostic via ``init_chat_model``)
+has 12 tools and three independent gates on every tool return:
+
+1. **PHI gate** — regex catalog (Aadhaar, PAN, MRN, phone, email,
+   precise dates) with a clinical-phrase allowlist.
+2. **k-anonymity gate (k=5)** — equivalence-class size check on
+   row-returning tools.
+3. **l-diversity gate (l=2)** — sensitive-attribute homogeneity check
+   added in PR #13 (v0.18.0).
+
+Plus three structural protections:
+
+* **Read-zone enforcement** —
+  :func:`scripts.ai_assistant.file_access.validate_agent_read` resolves
+  every path with ``os.path.realpath`` and verifies containment in
+  ``trio_bundle/`` ∪ ``agent/`` only. Audit, telemetry, staging, raw,
+  and the snapshot baseline are hard-rejected with
+  ``ZoneViolationError``.
+* **KeyStore (PR #3)** — API keys never live in the parent process's
+  ``os.environ``. The wizard's step 1 routes the pasted key into an
+  in-memory ``KeyStore`` registry; the corresponding ``*_API_KEY``
+  env variable is scrubbed. Keys are re-injected only into the
+  short-lived pipeline subprocess via ``KeyStore.env_for_subprocess``.
+* **Subprocess sandbox (PR #2)** — ``run_python_analysis`` runs in an
+  isolated subprocess with ``RLIMIT_AS`` / ``RLIMIT_NPROC`` /
+  ``RLIMIT_CPU`` rlimits, a sanitised env, and read-only access to
+  ``trio_bundle/`` only. The generated ``.py`` file is persisted to
+  ``output/{STUDY}/agent/analysis/{ts}.py`` for operator
+  reproduction.
+
+The Wizard
+----------
+
+The Streamlit web UI (``make chat``) walks the operator through three
+steps:
+
+1. **LLM** — pick provider + model, paste API key. Key goes straight
+   into the in-memory KeyStore; never persisted to disk, never
+   leaked into ``os.environ``.
+2. **Data** — two top-level buttons (PR #18 rewrite):
+
+   * *Use Existing Study* — skip the pipeline, trust whatever's
+     published in ``output/{STUDY}/trio_bundle/``. Disabled when no
+     bundle exists.
+   * *Load Study* — run the pipeline subprocess. The PDF
+     orchestrator runs in this path; per-PDF fallback to the
+     snapshot baseline kicks in when the LLM tier is unavailable.
+
+3. **Chat** — confirm and start asking questions.
 
 Who Benefits
 ------------
 
-**Clinical researchers** who want immediate answers to epidemiological
-questions (incidence, risk factors, interaction effects) from their own
-study data without drafting a data-manager ticket.
-
-**Principal investigators** who want a live, auditable picture of cohort
-characteristics and outcome counts for grant reports and steering-committee
-meetings.
-
-**Data managers** who are tired of being a human JOIN engine, and who want
-a defensible PHI story for every access.
-
-**IRB / Institutional Ethics Committee reviewers** who want a single
-evidence artifact (``audit/lineage_manifest.json``) pairing every raw input
-hash with every published trio artifact hash, plus a 31-criterion
-conformance matrix (plus four follow-ups added in patches
-2026-04-23a/b) tied to HIPAA / DPDPA / SPDI / Aadhaar Act / ICMR /
-NIST SP 800-188 / RePORT India Common Protocol.
-
-**Epidemiologists** who want reproducible models — the pipeline preserves
-per-subject date intervals exactly under SANT jitter, so survival and
-person-time analyses run on the de-identified bundle return the same
-numbers they would on the raw data.
+* **Clinical researchers** who want immediate answers to
+  epidemiological questions (incidence, risk factors, interaction
+  effects) from their own study data without drafting a data-manager
+  ticket.
+* **Principal investigators** who want a live, auditable picture of
+  cohort characteristics and outcome counts for grant reports and
+  steering-committee meetings.
+* **Data managers** who are tired of being a human JOIN engine, and
+  who want a defensible PHI story for every access.
+* **IRB / Institutional Ethics Committee reviewers** who want a single
+  evidence artifact (``output/{STUDY}/audit/lineage_manifest.json``)
+  pairing every raw input hash with every published trio artifact
+  hash, plus a 35-criterion conformance matrix (31 original + 4 added via patches 2026-04-23a/b) tied to HIPAA, DPDPA,
+  SPDI, Aadhaar Act, ICMR, NIST SP 800-188, and the RePORT India
+  Common Protocol.
+* **Epidemiologists** who want reproducible models — the pipeline
+  preserves per-subject date intervals exactly under SANT jitter, so
+  survival and person-time analyses run on the de-identified bundle
+  return the same numbers they would on the raw data.
 
 When NOT to Use It
 ------------------
 
-RePORT AI Portal is deliberately narrow. Do **not** reach for it when:
+RePORT AI Portal is deliberately narrow. Do **not** reach for it
+when:
 
-* **You need multi-study federated analysis.** The runtime is single-study
-  by design. Multi-study workflows, HPC deployment, and federated
-  aggregation are explicitly out of scope.
+* **You need multi-study federated analysis.** The runtime is
+  single-study by design. Multi-study workflows, HPC deployment, and
+  federated aggregation are explicitly out of scope.
 * **You need structured data-cleaning.** The pipeline scrubs PHI and
-  propagates duplicate-column drops; it does not impute, harmonize units,
-  or resolve coding discrepancies. Those remain data-manager work.
-* **You need to upload new data through a UI.** Data lands in
-  ``data/raw/{STUDY}/`` out-of-band; the agent reads the published bundle
-  only. There is no upload-then-chat flow.
-* **You want a general-purpose chatbot.** System prompts are ground-truthed
-  against the study's data dictionary and grounded answers only. Off-study
-  questions return "I don't have that data" rather than LLM hallucinations.
+  applies an honest-broker catalog, but it does not impute missing
+  values, harmonise units across studies, or perform feature
+  engineering. Bring your own cleaning step downstream.
+* **Your raw data is already de-identified to a public standard.**
+  This pipeline is overkill for a published WHO indicator dump or a
+  publicly-released SDTM submission. Use plain pandas.
+* **You need an answer right now and the inputs aren't checked in.**
+  ``data/raw/{STUDY}/`` must exist with ``datasets/``,
+  ``data_dictionary/``, and (optionally) ``annotated_pdfs/``. The
+  pipeline cannot conjure them.
 
-What's in the Bundle
---------------------
+Where To Go Next
+----------------
 
-After ``make pipeline`` succeeds, ``output/{STUDY}/trio_bundle/`` contains
-three companion artifacts the agent consults:
-
-* ``datasets/`` — scrubbed JSONL, one file per study form. All direct and
-  indirect identifiers dropped, pseudonymized, generalized, capped, or
-  suppressed per the 8-action catalogue. Dates jittered per-subject with
-  constant offset so intervals survive unchanged.
-* ``dictionary/`` — the study data dictionary in JSONL (variable name →
-  type → valid values → description).
-* ``pdfs/`` — structured variable definitions extracted from annotated CRF
-  PDFs (form-level metadata that doesn't fit in the dictionary).
-
-Plus the sibling ``audit/`` directory containing ``phi_scrub_report.json``
-(counts per action per field, no raw values), ``dataset_cleanup_report.json``,
-``dictionary_cleanup_report.json``, ``pdfs_cleanup_report.json``, and
-``lineage_manifest.json`` (the one-page IRB evidence artifact).
-
-How You Use It
---------------
-
-Two ways.
-
-**Interactive chat.** ``make chat`` launches a Streamlit web UI with an
-input box and a plot/table pane. Ask epidemiological questions in plain
-English; the ReAct agent routes to structured tools (variable lookup,
-dataset query, stats, plot rendering) and answers with citations back to
-the bundle. See :doc:`quickstart` for a 10-minute walkthrough.
-
-**Scripted pipeline run.** ``make pipeline`` runs the full extract →
-scrub → publish flow and produces the bundle + audit reports. Run this
-once per data refresh, then query via chat for as many iterations as the
-research question needs.
-
-Project Status
---------------
-
-Current version: |version|. The runtime implements the four-tier
-honest-broker architecture with a 31-criterion IRB benchmark (plus four
-follow-ups added in patches 2026-04-23a/b) satisfied architecturally
-(784 passing tests via ``make test-all``; 712 deterministic via
-``make test``; zero new lint or mypy errors). See
-``docs/irb_dossier/conformance_matrix.md`` for the full evidence matrix
-and ``docs/irb_dossier/executive_summary.md`` for the IEC reviewer
-orientation.
+* :doc:`installation` — system requirements + one-shot install
+  (``uv sync --all-groups``).
+* :doc:`quickstart` — ten-minute walkthrough from clone to first
+  answer.
+* :doc:`data_pipeline` — the full pipeline in operator terms.
+* :doc:`configuration` — every runtime knob, including the PHI-safety
+  flags + the KeyStore credential-handling note.
+* :doc:`../developer_guide/index` — for contributors and code reviewers.
+* ``docs/irb_dossier/`` (outside the Sphinx tree) — the IRB-grade
+  evidence package: 35-criterion conformance matrix (31 original + 4 added via patches 2026-04-23a/b), PHI walkthrough,
+  executive summary.


### PR DESCRIPTION
## Summary

Part 2 of the rewrite series. PR #27 did the structural consolidation (AGENTS.md + snapshots/README into Sphinx). This PR rewrites the three Sphinx pages with the most accumulated drift, **from first principles against the v0.20.0 code state** rather than patching.

| Page | Before | After | Why a full rewrite |
|---|---|---|---|
| `user_guide/overview.rst` | 136 lines, pre-PR-#15/#18 | 233 lines | Centres the four-zone model + names the orchestrator + the wizard's two-button flow + the three agent gates (PHI / k=5 / l=2) |
| `user_guide/data_pipeline.rst` | 322 lines, post-PR-#18 diagram bolted on | 263 lines | Rewrote as: top-level flow diagram → step-by-step prose → output structure → audit envelope → failure semantics. All 9 pipeline steps documented in current order |
| `developer_guide/data_extraction_pdfs.rst` | 135 lines, legacy-first | 195 lines | Orchestrator-first narrative. Dispatch table → 6-step orchestrator pipeline → capability + provider gates → legacy path → schema → CLI |

## Pages NOT rewritten (deferred to a future PR)

- `developer_guide/architecture.rst` (~500 lines) — drift patched in earlier PRs; structurally large enough to merit its own rewrite PR
- `developer_guide/tech_stack.rst` — pdfplumber section already rewritten in PR #20
- `developer_guide/decisions.rst` — ADR-006 supersedure note added in PR #20; older ADRs may have similar staleness
- `developer_guide/phi_architecture.rst` — long, never in the prior drift sweep
- `user_guide/configuration.rst` — already accurate post PR #20 + #24

## Test plan

- [x] 913 pass + 3 skip
- [x] ruff strict clean
- [x] doc-freshness lint passes (caught two specific drifts in the rewrite — `"only zone"` phrasing and missing `35-criterion` qualifier; both fixed)
- [x] Sphinx `-W` (warnings as errors) clean rebuild
- [x] No code touched