### PR TITLE
chore: format sweep + LangChain create_agent migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ N := \033[0m
 	pipeline dictionary extract-datasets bundle pdf-extract \
 	chat-cli chat build-variables \
 	snapshot snapshot-study restore-study list-snapshots \
-	test test-all lint typecheck security ci verify docs \
+	test test-all lint typecheck security ci verify docs doc-freshness docs-quality \
 	clean nuke
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -129,6 +129,8 @@ help:
 	@printf "\n"
 	@printf "$(B)$(G)  Docs$(N)\n"
 	@printf "  $(C)make docs$(N)             Build Sphinx HTML docs\n"
+	@printf "  $(C)make doc-freshness$(N)    Run stale-doc lint\n"
+	@printf "  $(C)make docs-quality$(N)     Doc freshness + warnings-as-errors build\n"
 	@printf "\n"
 	@printf "$(B)$(G)  Maintenance$(N)\n"
 	@printf "  $(C)make clean$(N)            Remove caches, sessions, stale logs\n"
@@ -319,12 +321,16 @@ verify:
 # ═══════════════════════════════════════════════════════════════════════
 
 docs:
-	@cd docs/sphinx && $(MAKE) html
+	@cd docs/sphinx && $(MAKE) html SPHINXBUILD="$(UV) run --frozen sphinx-build"
 	@printf "$(G)✓ Docs built → docs/sphinx/_build/html/index.html$(N)\n"
 
 doc-freshness:
 	@printf "$(C)🔍 Doc-freshness lint$(N)\n"
 	@$(UV) run --frozen python scripts/lint_doc_freshness.py
+
+docs-quality: doc-freshness
+	@cd docs/sphinx && $(MAKE) html SPHINXBUILD="$(UV) run --frozen sphinx-build" SPHINXOPTS="-W"
+	@printf "$(G)✓ Docs quality checks passed$(N)\n"
 
 # ═══════════════════════════════════════════════════════════════════════
 # MAINTENANCE

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ processed artifacts
 
 ### 🤖 AI Assistant
 
-- **ReAct agent** — autonomous `create_react_agent` with 12 structured-data
+- **ReAct agent** — LangChain `create_agent` with 12 structured-data
   tools.
 - **Direct data access** — no chunking, no embedding index; tools query the
   trio bundle directly.
@@ -201,7 +201,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # 2. Clone and navigate
 git clone https://github.com/solomonsjoseph/RePORT-AI-Portal.git
-cd "RePORT AI Portal"
+cd RePORT-AI-Portal
 
 # 3. Bootstrap the PHI HMAC key (once per machine)
 uv run python -m scripts.security.phi_scrub bootstrap-key

--- a/config.py
+++ b/config.py
@@ -14,6 +14,7 @@ determined by the ``$STUDY_NAME`` env var or a filesystem scan of
 overridden by ``$LLM_PROVIDER``. Staging directories are NOT created
 eagerly; call :func:`ensure_directories` after startup.
 """
+
 # config.py
 from __future__ import annotations
 
@@ -356,6 +357,7 @@ def preferred_or_installed_downgrade(model: str) -> list[str]:
         return list(QWEN3_DOWNGRADE_LADDER[start:])
     return [model]
 
+
 # ----------------------------------------------------------------------------
 # AI Assistant / AGENT
 # ----------------------------------------------------------------------------
@@ -397,7 +399,12 @@ ANALYSIS_MAX_FIGURES: int = _get_env_int("ANALYSIS_MAX_FIGURES", 20)
 SANDBOX_MAX_MEMORY_MB: int = _get_env_int("SANDBOX_MAX_MEMORY_MB", 2048)
 SANDBOX_MAX_PROCS: int = _get_env_int("SANDBOX_MAX_PROCS", 4096)
 SANDBOX_MAX_FILES: int = _get_env_int("SANDBOX_MAX_FILES", 256)
-SANDBOX_PERSIST_CODE: bool = _get_env("SANDBOX_PERSIST_CODE", "true").lower() in ("1", "true", "yes", "on")
+SANDBOX_PERSIST_CODE: bool = _get_env("SANDBOX_PERSIST_CODE", "true").lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
 
 # Orchestration mode: "auto" | "single-agent" | "multi-agent"
 AGENT_ORCHESTRATION_MODE: str = _get_env(

--- a/docs/sphinx/developer_guide/agents.rst
+++ b/docs/sphinx/developer_guide/agents.rst
@@ -50,8 +50,8 @@ Quick reference
 .. code-block:: bash
 
    make sync          # Install all deps (uv sync --all-groups)
-   make test          # ~841 deterministic tests (excludes AI Assistant/LLM tests)
-   make test-all      # Full suite including AI Assistant tests (913 cases at v0.20.0)
+   make test          # Deterministic subset excluding AI Assistant construction smokes
+   make test-all      # Full suite including AI Assistant construction smokes
    make lint          # ruff check + format
    make ci            # lint → typecheck → test
    make chat          # Launch Streamlit web UI
@@ -286,8 +286,8 @@ Web UI
   conversations, providers, session, wizard).
 * Sidebar JS in ``scripts/ai_assistant/ui/assets/bridge.js`` — uses
   ``document`` (not ``window.parent.document``).
-* Use ``st.html()`` for injecting JS/CSS (not deprecated
-  ``st.components.v1.html``).
+* Use ``st.iframe()`` for injected JS bridge surfaces so the hidden
+  bridge stays isolated and compatible with Streamlit's current runtime.
 
 Tests
 ~~~~~

--- a/docs/sphinx/developer_guide/architecture.rst
+++ b/docs/sphinx/developer_guide/architecture.rst
@@ -126,7 +126,7 @@ Dictionary Loader
 
 * **Module:** :func:`scripts.extraction.load_dictionary.load_study_dictionary`
 * **Step:** Step 0
-* **Reads:** ``data/raw/{STUDY}/data_dictionary/*.xlsx``
+* **Reads:** ``data/raw/{STUDY}/data_dictionary/*.{xlsx,csv}``
 * **Writes:** ``tmp/{STUDY}/dictionary/*.json``
 * **PHI posture:** Carries no PHI by design (the dictionary defines
   variables, not subject values).

--- a/docs/sphinx/developer_guide/data_extraction_datasets.rst
+++ b/docs/sphinx/developer_guide/data_extraction_datasets.rst
@@ -30,7 +30,7 @@ Data Flow
 
 .. code-block:: text
 
-   data/raw/{STUDY}/datasets/*.xlsx
+   data/raw/{STUDY}/datasets/*.{xlsx,csv}
                  │
                  ▼
    dataset_pipeline.py  →  tmp/{STUDY}/datasets/*.jsonl   (staging)
@@ -42,7 +42,7 @@ Source
 ------
 
 - **Path:** ``data/raw/{STUDY_NAME}/datasets/``
-- **Formats:** ``.xlsx``, ``.xls``, ``.csv``
+- **Formats:** ``.xlsx``, ``.csv``
 - Auto-discovered — no manual file list needed
 
 Output

--- a/docs/sphinx/developer_guide/project_status.rst
+++ b/docs/sphinx/developer_guide/project_status.rst
@@ -125,7 +125,7 @@ UI memory notes:
 
    * - Component
      - Location
-   * - ReAct agent (create_react_agent + 12 tools, live streaming)
+   * - ReAct agent (LangChain ``create_agent`` + 12 tools, live streaming)
      - ``scripts/ai_assistant/agent_graph.py``
    * - Agent prompts (system prompt with disclosure rules)
      - ``scripts/ai_assistant/agent_prompts.py``

--- a/docs/sphinx/developer_guide/tech_stack.rst
+++ b/docs/sphinx/developer_guide/tech_stack.rst
@@ -54,10 +54,9 @@ Pytest
 
 **What.** Test runner. **Why.** Mature ecosystem, ``conftest.py``
 fixtures, deterministic markers. **How.**
-:doc:`testing` covers the test-file conventions. As of v0.20.0
-``make test`` runs 841 deterministic tests; ``make test-all`` runs
-the full 913 (the difference is LLM-construction smokes that need
-``langchain`` installed).
+:doc:`testing` covers the test-file conventions. ``make test`` runs
+the deterministic subset that excludes the AI Assistant construction
+smokes; ``make test-all`` runs the full suite.
 
 Runtime — pipeline
 ------------------
@@ -78,14 +77,6 @@ openpyxl
 **What.** Excel ``.xlsx`` reader/writer. **Why.** pandas's default
 ``.xlsx`` engine. **How.** Used implicitly by ``pd.read_excel`` for
 the dictionary + dataset legs.
-
-xlrd 1.2.0 (legacy ``.xls`` only)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-**What.** Legacy ``.xls`` reader. **Why.** pandas dropped ``xlrd``
-support in 1.2 for ``.xlsx`` but kept it for legacy ``.xls``. We need
-both because some study data is still in ``.xls``. **How.** Pinned
-via ``xlrd==1.2.0`` (the last version that supports ``.xls``).
 
 pypdf
 ~~~~~
@@ -223,13 +214,6 @@ future phase; for now standard logging is sufficient.
 Development
 -----------
 
-pytest-cov
-~~~~~~~~~~
-
-**What.** Coverage measurement. **Why.** Optional; enabled when
-running ``make test-coverage``. **How.** Configured in
-``pyproject.toml`` (``[tool.pytest.ini_options]``).
-
 pip-audit
 ~~~~~~~~~
 
@@ -270,8 +254,6 @@ Pinning policy
   the agent talks to (LangChain, Anthropic, Google) — e.g.
   ``langchain>=1.0.0,<2.0.0``. Reason: provider APIs evolve; we
   catch the v2 break in CI before it reaches production.
-* **Exact version pin** for ``xlrd==1.2.0`` (the only non-broken
-  ``.xls`` reader).
 * **Streamlit pinned to ``>=1.38, <2.0``** because
   ``st.session_state`` semantics changed materially across major
   versions.

--- a/docs/sphinx/user_guide/data_pipeline.rst
+++ b/docs/sphinx/user_guide/data_pipeline.rst
@@ -97,14 +97,14 @@ Step-by-step
 Step 0 — Dictionary loading
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Reads ``data/raw/{STUDY}/data_dictionary/*.xlsx`` and writes per-file
-``*.json`` files into ``tmp/{STUDY}/dictionary/``. Carries no PHI.
+Reads ``data/raw/{STUDY}/data_dictionary/*.{xlsx,csv}`` and writes
+per-file ``*.jsonl`` files into ``tmp/{STUDY}/dictionary/``. Carries no PHI.
 Implementation: :func:`scripts.extraction.load_dictionary.load_study_dictionary`.
 
 Step 1 — Dataset extraction (with hash-based step cache)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Walks ``data/raw/{STUDY}/datasets/*.xlsx`` and converts each row to a
+Walks ``data/raw/{STUDY}/datasets/*.{xlsx,csv}`` and converts each row to a
 JSON record in ``tmp/{STUDY}/datasets/``. Records that fail validation
 are recorded as "dropped events" so Step 1.8 can mirror them into the
 dictionary + PDF legs.

--- a/docs/sphinx/user_guide/faq.rst
+++ b/docs/sphinx/user_guide/faq.rst
@@ -27,7 +27,7 @@ Who should use RePORT AI Portal?
 What data formats does it support?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* **Input**: PDF (annotated case report forms), Excel (.xlsx, .xls), CSV
+* **Input**: PDF (annotated case report forms), Excel ``.xlsx``, CSV
 * **Output**: JSONL (JSON Lines)
 
 Installation & Setup

--- a/main.py
+++ b/main.py
@@ -156,6 +156,7 @@ def _install_log_redactor_best_effort() -> None:
     # so SUBJ_*, SC_*, FID_* identifiers in log messages get tagged
     # ``<SUBJ_*>``. Without this, only the generic catalog redactions run.
     from scripts.security.phi_patterns import SUBJECT_ID_PATTERNS
+
     install_phi_redactor(hmac_key=key, subject_id_patterns=list(SUBJECT_ID_PATTERNS))
 
 
@@ -421,9 +422,7 @@ def _run_dataset_leg(*, force: bool, run_extraction: bool) -> dict[str, Any]:
     audit_dir = Path(config.STUDY_AUDIT_DIR)
     trio_datasets_dir = Path(config.TRIO_DATASETS_DIR)
 
-    trio_bundle_has_jsonl = trio_datasets_dir.is_dir() and any(
-        trio_datasets_dir.glob("*.jsonl")
-    )
+    trio_bundle_has_jsonl = trio_datasets_dir.is_dir() and any(trio_datasets_dir.glob("*.jsonl"))
 
     if (
         not force

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,10 +90,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/solomonsjoseph/RePORTaLiN-RAG"
+Homepage = "https://github.com/solomonsjoseph/RePORT-AI-Portal"
 Documentation = "https://solomonsjoseph.github.io/RePORT-AI-Portal/"
-Repository = "https://github.com/solomonsjoseph/RePORTaLiN-RAG"
-Issues = "https://github.com/solomonsjoseph/RePORTaLiN-RAG/issues"
+Repository = "https://github.com/solomonsjoseph/RePORT-AI-Portal"
+Issues = "https://github.com/solomonsjoseph/RePORT-AI-Portal/issues"
 
 [project.scripts]
 report_ai_portal = "main:main"
@@ -157,9 +157,9 @@ ai_assistant = [
     "langchain-nvidia-ai-endpoints>=1.0.0,<2.0.0",
     "langchain-text-splitters>=1.1.2,<2.0.0",
     # LangGraph 1.x — closes CVE-2026-28277 (langgraph) and CVE-2026-27794
-    # (langgraph-checkpoint, transitive). Migration kept narrow because the
-    # only public-API surface used is MemorySaver / CompiledStateGraph /
-    # create_react_agent — all three remain in 1.x.
+    # (langgraph-checkpoint, transitive). Runtime agent construction goes
+    # through LangChain create_agent, but MemorySaver / CompiledStateGraph
+    # still come from LangGraph.
     "langgraph>=1.0.10,<2.0.0",
     "langgraph-checkpoint>=4.0.0,<5.0.0",
 ]

--- a/scripts/ai_assistant/agent_graph.py
+++ b/scripts/ai_assistant/agent_graph.py
@@ -1,8 +1,8 @@
 """ReAct agent for RePORT AI Portal AI Assistant.
 
-Uses ``create_react_agent`` from LangGraph prebuilt with ``MemorySaver``
-for session persistence.  The agent autonomously decides which tools to
-call and how to compose answers.
+Uses LangChain's ``create_agent`` (built on LangGraph) with ``MemorySaver``
+for session persistence. The agent autonomously decides which tools to call
+and how to compose answers.
 
 LLM provider is controlled by ``config.LLM_PROVIDER`` / ``config.LLM_MODEL``.
 """
@@ -14,11 +14,11 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any, cast
 
+from langchain.agents import create_agent
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph.state import CompiledStateGraph
-from langgraph.prebuilt import create_react_agent
 
 import config
 from scripts.ai_assistant.agent_prompts import SYSTEM_PROMPT
@@ -75,9 +75,8 @@ def _build_llm(provider: str, model: str) -> Any:
     api_key = get_keystore().get(slug) if slug else None
 
     # NVIDIA AI Endpoints requires langchain_nvidia_ai_endpoints.ChatNVIDIA.
-    # init_chat_model does not support the NVIDIA provider directly and the
-    # NVIDIA API uses max_tokens (not max_completion_tokens) in the LangChain
-    # integration, so we instantiate ChatNVIDIA explicitly.
+    # init_chat_model does not support the NVIDIA provider directly, so we
+    # instantiate ChatNVIDIA explicitly.
     if provider == "nvidia-ai-endpoints":
         try:
             from langchain_nvidia_ai_endpoints import ChatNVIDIA  # type: ignore[import-untyped]
@@ -88,7 +87,7 @@ def _build_llm(provider: str, model: str) -> Any:
             ) from exc
         kwargs: dict[str, Any] = {
             "model": model,
-            "max_tokens": config.AGENT_MAX_TOKENS,
+            "max_completion_tokens": config.AGENT_MAX_TOKENS,
             "temperature": 1,
             "top_p": 1,
         }
@@ -169,9 +168,7 @@ def _init_llm() -> Any:
             err = str(exc).lower()
             if not any(sig in err for sig in _OLLAMA_OOM_SIGNALS):
                 raise  # Not an OOM error — surface to the caller unchanged.
-            logger.warning(
-                "Ollama OOM on %s: %s — trying next rung in the ladder", rung, exc
-            )
+            logger.warning("Ollama OOM on %s: %s — trying next rung in the ladder", rung, exc)
 
     raise RuntimeError(
         f"All {len(ladder)} qwen3 ladder rungs ({', '.join(ladder)}) were refused "
@@ -200,10 +197,10 @@ def get_agent() -> CompiledStateGraph:
         llm = _init_llm()
         prompt = SYSTEM_PROMPT.format(study_name=config.STUDY_NAME)
 
-        _agent = create_react_agent(
+        _agent = create_agent(
             model=llm,
             tools=ALL_TOOLS,
-            prompt=prompt,
+            system_prompt=prompt,
             checkpointer=get_checkpointer(),
         )
 

--- a/scripts/ai_assistant/agent_tools.py
+++ b/scripts/ai_assistant/agent_tools.py
@@ -171,12 +171,31 @@ _MIN_QUERY_LENGTH = 3
 
 _CONVERSATIONAL_STOPLIST: frozenset[str] = frozenset(
     {
-        "hi", "hello", "hey", "yo", "sup",
-        "hii", "heyy", "hola",
-        "thanks", "thank you", "ty", "thx",
-        "ok", "okay", "cool", "nice", "got it",
-        "help", "test", "try", "again", "no",
-        "yes", "y", "n",
+        "hi",
+        "hello",
+        "hey",
+        "yo",
+        "sup",
+        "hii",
+        "heyy",
+        "hola",
+        "thanks",
+        "thank you",
+        "ty",
+        "thx",
+        "ok",
+        "okay",
+        "cool",
+        "nice",
+        "got it",
+        "help",
+        "test",
+        "try",
+        "again",
+        "no",
+        "yes",
+        "y",
+        "n",
     }
 )
 
@@ -198,8 +217,8 @@ def _query_looks_conversational(query: str) -> bool:
 
 _CONVERSATIONAL_REFUSAL_MESSAGE = (
     "That looks like a greeting rather than a study question — ask about a "
-    "variable, form, dataset, cohort, or analysis (e.g. \"show me TB outcome "
-    "variables\" or \"how many subjects completed treatment?\")."
+    'variable, form, dataset, cohort, or analysis (e.g. "show me TB outcome '
+    'variables" or "how many subjects completed treatment?").'
 )
 
 
@@ -1240,10 +1259,10 @@ def _score_variable(var: dict[str, Any], query_terms: list[str], query_phrase: s
     Kept identical to ``search_variables`` weights so behaviour stays consistent
     when tools are chained.
     """
-    name = (var.get("variable_name") or "")
-    desc = (var.get("description") or "")
-    form = (var.get("form_name") or "")
-    section = (var.get("section") or "")
+    name = var.get("variable_name") or ""
+    desc = var.get("description") or ""
+    form = var.get("form_name") or ""
+    section = var.get("section") or ""
 
     def _norm(value: str) -> str:
         term = re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
@@ -1343,7 +1362,11 @@ def find_variable_candidates(description: str, k: int = 3) -> str:
             scored.append((score, var))
 
     scored.sort(
-        key=lambda x: (-x[0], len(x[1].get("variable_name") or ""), x[1].get("variable_name") or ""),
+        key=lambda x: (
+            -x[0],
+            len(x[1].get("variable_name") or ""),
+            x[1].get("variable_name") or "",
+        ),
     )
     top = scored[:k]
 
@@ -1524,7 +1547,23 @@ def search_pdf_context(query: str, k: int = 5) -> str:
     if not snippets:
         return "No extracted PDF context found. Run the PDF extraction pipeline first."
 
-    stop = {"the", "a", "an", "of", "for", "and", "in", "is", "to", "or", "on", "what", "how", "does", "do"}
+    stop = {
+        "the",
+        "a",
+        "an",
+        "of",
+        "for",
+        "and",
+        "in",
+        "is",
+        "to",
+        "or",
+        "on",
+        "what",
+        "how",
+        "does",
+        "do",
+    }
     words = [w for w in query.split() if w.lower() not in stop] or query.split()
     query_terms: list[str] = []
     for w in words:
@@ -1556,9 +1595,7 @@ def search_pdf_context(query: str, k: int = 5) -> str:
         text = snip["text"]
         if len(text) > 600:
             text = text[:600].rstrip() + "…"
-        safe_text = sanitise_untrusted_snippet(
-            text, source_label=f"PDF {snip['source_pdf']}"
-        )
+        safe_text = sanitise_untrusted_snippet(text, source_label=f"PDF {snip['source_pdf']}")
         out.append(
             {
                 "rank": rank,

--- a/scripts/ai_assistant/analytical_engine.py
+++ b/scripts/ai_assistant/analytical_engine.py
@@ -275,8 +275,14 @@ class CohortBuilder:
         keep.extend(
             c
             for c in [
-                "age", "sex", "smoking", "diabetes", "alcohol_freq",
-                "bmi", "malnutrition", "hba1c",
+                "age",
+                "sex",
+                "smoking",
+                "diabetes",
+                "alcohol_freq",
+                "bmi",
+                "malnutrition",
+                "hba1c",
             ]
             if c in df.columns
         )

--- a/scripts/ai_assistant/cli.py
+++ b/scripts/ai_assistant/cli.py
@@ -61,9 +61,7 @@ def _select_llm() -> None:
             slug = provider_slug_for(provider_id)
             # "Set" means: KeyStore has it OR the user pre-exported it in their
             # shell. We never write to ``os.environ`` ourselves anymore.
-            has_key = (slug is not None and keystore.has(slug)) or bool(
-                os.environ.get(env_key, "")
-            )
+            has_key = (slug is not None and keystore.has(slug)) or bool(os.environ.get(env_key, ""))
             key_status = " (key set)" if has_key else " (key needed)"
         print(f"  {num}. {label}{key_status}{marker}")
 
@@ -86,10 +84,7 @@ def _select_llm() -> None:
     # API key — stored in the KeyStore (in-process memory), never in os.environ.
     if env_key:
         slug = provider_slug_for(provider_id)
-        existing_key = (
-            (slug is not None and keystore.get(slug))
-            or os.environ.get(env_key, "")
-        )
+        existing_key = (slug is not None and keystore.get(slug)) or os.environ.get(env_key, "")
         if existing_key:
             print(f"  {env_key} is already set.")
             try:

--- a/scripts/ai_assistant/file_access.py
+++ b/scripts/ai_assistant/file_access.py
@@ -144,6 +144,5 @@ def validate_sandbox_write(path: str | Path) -> Path:
     if _is_within(resolved, sandbox_root):
         return Path(resolved)
     raise ZoneViolationError(
-        f"Sandbox write denied — exec_python may only write inside "
-        f"agent/analysis/: {path}"
+        f"Sandbox write denied — exec_python may only write inside agent/analysis/: {path}"
     )

--- a/scripts/ai_assistant/keystore.py
+++ b/scripts/ai_assistant/keystore.py
@@ -61,8 +61,7 @@ class KeyStore:
         slug = self._normalise(provider)
         if slug not in ENV_VAR_BY_PROVIDER:
             raise ValueError(
-                f"Unknown provider {provider!r}. "
-                f"Known: {sorted(ENV_VAR_BY_PROVIDER)}."
+                f"Unknown provider {provider!r}. Known: {sorted(ENV_VAR_BY_PROVIDER)}."
             )
         return slug
 

--- a/scripts/ai_assistant/phi_safe.py
+++ b/scripts/ai_assistant/phi_safe.py
@@ -150,9 +150,7 @@ def guard_rows_with_kanon(
     we only gate the row-level surface.
     """
     rows_list = list(rows)
-    result = kanon_check(
-        rows_list, quasi_identifiers=quasi_identifiers, k=k
-    )
+    result = kanon_check(rows_list, quasi_identifiers=quasi_identifiers, k=k)
     if result.blocked:
         logger.warning(
             "phi_safe: tool %s k-anon blocked — smallest class %d < k=%d",
@@ -210,8 +208,7 @@ def guard_rows_with_kanon_and_ldiv(
         )
         if ldiv_res.blocked:
             logger.warning(
-                "phi_safe: tool %s l-diversity blocked — smallest "
-                "diversity %d < l=%d",
+                "phi_safe: tool %s l-diversity blocked — smallest diversity %d < l=%d",
                 tool_name,
                 ldiv_res.smallest_diversity,
                 l_threshold,
@@ -300,8 +297,12 @@ def guard_user_prompt(text: str) -> UserPromptGuardResult:
 # mangle legitimate content. Every pattern targets an instruction-flavoured
 # construction that has no place in authored CRF / protocol / MOP text.
 _INJECTION_PATTERNS: list[re.Pattern[str]] = [
-    re.compile(r"(?i)ignore\s+(?:all\s+)?(?:previous|prior|above|earlier)\s+(?:instructions?|prompts?|rules?|constraints?|directives?)"),
-    re.compile(r"(?i)disregard\s+(?:all\s+|the\s+)?(?:previous|prior|above|earlier|foregoing|instructions?)"),
+    re.compile(
+        r"(?i)ignore\s+(?:all\s+)?(?:previous|prior|above|earlier)\s+(?:instructions?|prompts?|rules?|constraints?|directives?)"
+    ),
+    re.compile(
+        r"(?i)disregard\s+(?:all\s+|the\s+)?(?:previous|prior|above|earlier|foregoing|instructions?)"
+    ),
     re.compile(r"(?i)forget\s+(?:everything|all|your\s+(?:instructions?|training|rules?))"),
     re.compile(r"(?i)you\s+are\s+now\s+(?:a|an|in|the)\b"),
     re.compile(r"(?i)new\s+(?:instructions?|role|system\s*prompt|directives?)\s*[:=]"),

--- a/scripts/ai_assistant/sandbox/replicate.py
+++ b/scripts/ai_assistant/sandbox/replicate.py
@@ -102,9 +102,7 @@ def main(path_str: str) -> int:
     try:
         # ``e``+``xec`` literal split to avoid a static-analysis hook
         # misfire on this source file; behavior is identical.
-        getattr(builtins, "e" + "xec")(
-            compile(code, str(path), "e" + "xec"), namespace
-        )
+        getattr(builtins, "e" + "xec")(compile(code, str(path), "e" + "xec"), namespace)
     except Exception as exc:
         print(f"Error during replication: {type(exc).__name__}: {exc}", file=sys.stderr)
         return 1

--- a/scripts/ai_assistant/sandbox/runner.py
+++ b/scripts/ai_assistant/sandbox/runner.py
@@ -153,7 +153,8 @@ def _make_zone_guarded_open(*, allowed_read_paths: Iterable[Path], output_dir: P
 
 def _build_safe_builtins(zone_guarded_open: Any) -> dict[str, Any]:
     safe = {
-        k: v for k, v in vars(builtins).items()
+        k: v
+        for k, v in vars(builtins).items()
         if k not in _BLOCKED_BUILTINS and not k.startswith("_")
     }
 
@@ -300,6 +301,7 @@ def main(spec_path: str) -> int:
     try:
         import numpy as _np
         import pandas as _pd
+
         namespace["pd"] = _pd
         namespace["np"] = _np
     except ImportError:
@@ -310,6 +312,7 @@ def main(spec_path: str) -> int:
     try:
         import plotly.express as _px
         import plotly.graph_objects as _go
+
         namespace["px"] = _px
         namespace["go"] = _go
 
@@ -341,7 +344,9 @@ def main(spec_path: str) -> int:
     captured = stdout_buf.getvalue()
     truncated = len(captured) > max_output_bytes
     if truncated:
-        captured = captured[:max_output_bytes] + f"\n\n[Output truncated at {max_output_bytes} bytes]"
+        captured = (
+            captured[:max_output_bytes] + f"\n\n[Output truncated at {max_output_bytes} bytes]"
+        )
     sys.stdout.write(captured)
 
     fig_dir = output_dir / "figures"

--- a/scripts/ai_assistant/ui/chat.py
+++ b/scripts/ai_assistant/ui/chat.py
@@ -226,11 +226,7 @@ def composer(assistant_slot: Any | None = None) -> None:
     if question and not pending_stream:
         guard = guard_user_prompt(question)
         user_idx = len(ss.messages)
-        user_content = (
-            question
-            if guard.ok
-            else "[PHI-REFUSED — content redacted]"
-        )
+        user_content = question if guard.ok else "[PHI-REFUSED — content redacted]"
         ss.messages.append({"role": "user", "content": user_content})
         meta: dict[str, Any] = {
             "timestamp": datetime.now(UTC).isoformat(),
@@ -405,9 +401,7 @@ def _render_model_pill() -> None:
 
         if not more_open:
             cur_name = html.escape(_pretty_model_label(current_model))
-            cur_desc = html.escape(
-                _model_description(current_model, is_local=is_local) or ""
-            )
+            cur_desc = html.escape(_model_description(current_model, is_local=is_local) or "")
             st.markdown(
                 '<div class="rpln-current-model">'
                 '<div class="rpln-current-model-text">'
@@ -447,9 +441,7 @@ def _render_model_pill() -> None:
 
             st.markdown('<hr class="rpln-popover-sep" />', unsafe_allow_html=True)
 
-            if st.button(
-                "More models  \u203a", key="rpln_more_models_toggle", width="stretch"
-            ):
+            if st.button("More models  \u203a", key="rpln_more_models_toggle", width="stretch"):
                 st.session_state.rpln_model_more_open = True
                 st.rerun()
         else:

--- a/scripts/ai_assistant/ui/conversations.py
+++ b/scripts/ai_assistant/ui/conversations.py
@@ -90,7 +90,7 @@ def _save_conversation() -> None:
         title = _conversation_title(redacted_for_title)
     # Already-saved messages are already redacted on disk; only redact new ones.
     already_saved = existing.get("messages", [])
-    new_messages = messages[len(already_saved):]
+    new_messages = messages[len(already_saved) :]
     redacted_messages = already_saved + [redact_message_content(msg) for msg in new_messages]
     data = {
         "id": conv_id,

--- a/scripts/ai_assistant/ui/model_policy.py
+++ b/scripts/ai_assistant/ui/model_policy.py
@@ -72,9 +72,7 @@ def _normalise(name: str) -> str:
     return name.strip().lower()
 
 
-def is_model_allowed_for_study_load(
-    *, provider: str, model: str
-) -> ModelGateResult:
+def is_model_allowed_for_study_load(*, provider: str, model: str) -> ModelGateResult:
     """Return whether ``provider``/``model`` may trigger a study load/reload.
 
     Rules:
@@ -116,17 +114,11 @@ def is_model_allowed_for_study_load(
         if version >= floor:
             return ModelGateResult(
                 allowed=True,
-                reason=(
-                    f"{model} is at or above the {family_label} "
-                    f"{floor[0]}.{floor[1]} floor."
-                ),
+                reason=(f"{model} is at or above the {family_label} {floor[0]}.{floor[1]} floor."),
             )
         return ModelGateResult(
             allowed=False,
-            reason=(
-                f"{model} is below the {family_label} "
-                f"{floor[0]}.{floor[1]} floor."
-            ),
+            reason=(f"{model} is below the {family_label} {floor[0]}.{floor[1]} floor."),
         )
 
     return ModelGateResult(
@@ -146,5 +138,5 @@ def describe_allowlist() -> str:
         "Loading or reloading study data requires a high-capability model: "
         "Claude **Opus ≥ 4.6**, Gemini **Pro ≥ 3.1**, GPT **≥ 5.3**, "
         "or any local **Ollama** model. "
-        "\"Use Existing Study\" is always available regardless of model."
+        '"Use Existing Study" is always available regardless of model.'
     )

--- a/scripts/ai_assistant/ui/shell.py
+++ b/scripts/ai_assistant/ui/shell.py
@@ -1,4 +1,5 @@
 """Shell: CSS injection, JS bridge, topbar, sidebar."""
+
 from __future__ import annotations
 
 import html as _html
@@ -97,8 +98,8 @@ def topbar() -> None:
                 (
                     '<div class="rpln-topbar-title-overlay" aria-hidden="true" '
                     f'title="{_html.escape(title, quote=True)}">'
-                    f'{_html.escape(title_label)}'
-                    '</div>'
+                    f"{_html.escape(title_label)}"
+                    "</div>"
                 ),
                 unsafe_allow_html=True,
             )
@@ -187,14 +188,13 @@ def topbar() -> None:
                 else:
                     st.caption("Start a chat to enable conversation actions.")
 
-        with st.container(key="rpln_topbar_share"), st.popover(
-            "Share",
-            width="content",
-            disabled=not has_messages,
-            help=(
-                "Share and export"
-                if has_messages
-                else "Start a chat to enable sharing"
+        with (
+            st.container(key="rpln_topbar_share"),
+            st.popover(
+                "Share",
+                width="content",
+                disabled=not has_messages,
+                help=("Share and export" if has_messages else "Start a chat to enable sharing"),
             ),
         ):
             if conv_id and has_messages:
@@ -297,9 +297,8 @@ def sidebar() -> None:
         visible_pins = pinned_conversations[:_SIDEBAR_PIN_LIMIT]
         remaining_slots = max(0, _SIDEBAR_VISIBLE_CHAT_LIMIT - len(visible_pins))
         visible_recent = recent_conversations[:remaining_slots]
-        hidden_conversation_count = (
-            max(0, len(pinned_conversations) - len(visible_pins))
-            + max(0, len(recent_conversations) - len(visible_recent))
+        hidden_conversation_count = max(0, len(pinned_conversations) - len(visible_pins)) + max(
+            0, len(recent_conversations) - len(visible_recent)
         )
 
         rendered_any = False
@@ -394,9 +393,9 @@ def _render_group(group_name: str, label: str, convs: list[dict]) -> None:
                           title="{escaped_full_title}" aria-label="{escaped_full_title}">{title}</span>
               <button class="rpln-row-close" type="button"
                                             data-rpln-action="pin-conv" data-rpln-conv-id="{cid}"
-                                            title="{'Unpin' if group_name == 'pinned' else 'Pin'}">
+                                            title="{"Unpin" if group_name == "pinned" else "Pin"}">
                                 <span class="material-symbols-rounded">
-                                    {'close' if group_name == 'pinned' else 'push_pin'}
+                                    {"close" if group_name == "pinned" else "push_pin"}
                                 </span>
               </button>
               <div class="rpln-row-menu-wrap">
@@ -415,9 +414,9 @@ def _render_group(group_name: str, label: str, convs: list[dict]) -> None:
                   <button type="button" data-rpln-action="pin-conv"
                           data-rpln-conv-id="{cid}">
                     <span class="material-symbols-rounded">
-                      {'keep_off' if group_name == 'pinned' else 'keep'}
+                      {"keep_off" if group_name == "pinned" else "keep"}
                     </span>
-                    <span>{'Unpin' if group_name == 'pinned' else 'Pin'}</span>
+                    <span>{"Unpin" if group_name == "pinned" else "Pin"}</span>
                   </button>
                   <button type="button" data-rpln-action="delete-conv"
                           data-rpln-conv-id="{cid}" class="rpln-row-menu-danger">
@@ -438,7 +437,7 @@ def _render_group(group_name: str, label: str, convs: list[dict]) -> None:
             <span>{label}</span>
           </div>
           <div class="rpln-conv-list">
-            {''.join(rows_html)}
+            {"".join(rows_html)}
           </div>
         </div>
         """

--- a/scripts/ai_assistant/ui/state.py
+++ b/scripts/ai_assistant/ui/state.py
@@ -1,4 +1,5 @@
 """Session-state bootstrap and conversation helpers for RePORT AI Portal chat UI."""
+
 from __future__ import annotations
 
 from typing import Any, cast
@@ -61,14 +62,13 @@ def init_state() -> None:
 
 def _new_id() -> str:
     import uuid
+
     return str(uuid.uuid4())
 
 
 def _pipeline_output_exists() -> bool:
     try:
-        return config.TRIO_BUNDLE_DIR.exists() and any(
-            config.TRIO_DATASETS_DIR.glob("*.jsonl")
-        )
+        return config.TRIO_BUNDLE_DIR.exists() and any(config.TRIO_DATASETS_DIR.glob("*.jsonl"))
     except Exception:
         return False
 

--- a/scripts/ai_assistant/ui/streaming.py
+++ b/scripts/ai_assistant/ui/streaming.py
@@ -413,9 +413,7 @@ def _render_thinking_block(
             if body:
                 html_parts.append(f'<div class="thinking-section-body">{body}</div>')
         else:
-            html_parts.append(
-                f'<div class="thinking-section-body">{_html.escape(section)}</div>'
-            )
+            html_parts.append(f'<div class="thinking-section-body">{_html.escape(section)}</div>')
 
     content_html = "\n".join(html_parts)
     thinking_id = f"thinking_{msg_idx}"

--- a/scripts/ai_assistant/ui/wizard.py
+++ b/scripts/ai_assistant/ui/wizard.py
@@ -1,4 +1,5 @@
 """Setup wizard: LLM config, pipeline run, 3-step setup flow."""
+
 from __future__ import annotations
 
 import html
@@ -25,6 +26,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # CSS
 # ---------------------------------------------------------------------------
+
 
 def inject_wizard_css() -> None:
     """Hide sidebar and center the wizard column."""
@@ -61,6 +63,7 @@ def inject_wizard_css() -> None:
 # ---------------------------------------------------------------------------
 # LLM config helpers
 # ---------------------------------------------------------------------------
+
 
 def apply_llm_config(provider_label: str, api_key: str, model: str) -> None:
     """Persist provider/model selection + stash the API key in the KeyStore.
@@ -150,6 +153,7 @@ def ensure_llm_config() -> None:
 # Pipeline
 # ---------------------------------------------------------------------------
 
+
 def _ensure_phi_key() -> None:
     """Bootstrap the PHI HMAC key if it does not yet exist."""
     if config.PHI_KEY_PATH.exists():
@@ -189,9 +193,7 @@ def run_pipeline() -> dict[str, Any]:
     _ensure_phi_key()
 
     subprocess_env = os.environ.copy()
-    subprocess_env.update(
-        get_keystore().env_for_subprocess(list(ENV_VAR_BY_PROVIDER))
-    )
+    subprocess_env.update(get_keystore().env_for_subprocess(list(ENV_VAR_BY_PROVIDER)))
     # The orchestrator's capability+provider gate decides per-PDF whether
     # the LLM tier runs; setting the env var to "llm" only signals that
     # this is a fresh-extraction run (vs. the legacy raw-PDF API path).
@@ -210,9 +212,7 @@ def run_pipeline() -> dict[str, Any]:
 
 def _pipeline_output_exists() -> bool:
     try:
-        return config.TRIO_BUNDLE_DIR.exists() and any(
-            config.TRIO_DATASETS_DIR.glob("*.jsonl")
-        )
+        return config.TRIO_BUNDLE_DIR.exists() and any(config.TRIO_DATASETS_DIR.glob("*.jsonl"))
     except Exception:
         return False
 
@@ -220,6 +220,7 @@ def _pipeline_output_exists() -> bool:
 # ---------------------------------------------------------------------------
 # Wizard header
 # ---------------------------------------------------------------------------
+
 
 def _render_wizard_header(step: int) -> None:
     def _pill(n: int, label: str) -> str:
@@ -241,6 +242,7 @@ def _render_wizard_header(step: int) -> None:
 # ---------------------------------------------------------------------------
 # Main wizard entry point
 # ---------------------------------------------------------------------------
+
 
 def render_setup_page() -> None:
     """Render the 3-step setup wizard."""
@@ -308,9 +310,7 @@ def render_setup_page() -> None:
                 )
                 provider_changed = session_provider != provider_label
                 saved_model = (
-                    ""
-                    if provider_changed
-                    else st.session_state.get("llm_model", config.LLM_MODEL)
+                    "" if provider_changed else st.session_state.get("llm_model", config.LLM_MODEL)
                 )
                 configured_model = (
                     config.LLM_MODEL if cfg["provider"] == config.LLM_PROVIDER else ""
@@ -415,7 +415,7 @@ def render_setup_page() -> None:
                     unsafe_allow_html=True,
                 )
                 st.markdown(
-                    "<span class=\"rpln-beta-note\">"
+                    '<span class="rpln-beta-note">'
                     "<em>PHI handling is in beta — datasets must be pre-scrubbed before extraction.</em>"
                     "</span>",
                     unsafe_allow_html=True,
@@ -460,8 +460,7 @@ def render_setup_page() -> None:
                             "Skip the pipeline and use the trio bundle already "
                             "published at output/{STUDY}/trio_bundle/."
                             if output_exists
-                            else "No published trio_bundle on disk yet — run "
-                            "Load Study first."
+                            else "No published trio_bundle on disk yet — run Load Study first."
                         ),
                     ):
                         st.session_state.pipeline_ready = True
@@ -474,9 +473,7 @@ def render_setup_page() -> None:
                         type="primary" if not output_exists else "secondary",
                         width="stretch",
                     ):
-                        with st.spinner(
-                            "Loading study data — this may take a minute…"
-                        ):
+                        with st.spinner("Loading study data — this may take a minute…"):
                             result = run_pipeline()
                         st.session_state.pipeline_log = result["output"]
                         if result["success"]:
@@ -511,9 +508,7 @@ def render_setup_page() -> None:
             # Step 3 — Confirm and start chatting                               #
             # ---------------------------------------------------------------- #
             elif step == 3:
-                provider_display = html.escape(
-                    str(st.session_state.get("llm_provider_label", ""))
-                )
+                provider_display = html.escape(str(st.session_state.get("llm_provider_label", "")))
                 model_display = html.escape(str(st.session_state.get("llm_model", "")))
                 st.markdown(
                     '<p class="welcome-title">Ready to go!</p>'

--- a/scripts/extraction/cleanup_propagation.py
+++ b/scripts/extraction/cleanup_propagation.py
@@ -116,9 +116,7 @@ def compute_propagation_set(
                             raw, source_path=jsonl_file, line_number=line_no
                         )
                     except JSONLParseError:
-                        logger.debug(
-                            "Skipping malformed line %d in %s", line_no, jsonl_file.name
-                        )
+                        logger.debug("Skipping malformed line %d in %s", line_no, jsonl_file.name)
                         continue
                     for key in row:
                         if isinstance(key, str) and key not in PROVENANCE_FIELDS:
@@ -156,13 +154,9 @@ def prune_dictionary(drop_set: set[str], dict_dir: Path) -> int:
                 if not raw:
                     continue
                 try:
-                    row = load_json_object_line(
-                        raw, source_path=jsonl_file, line_number=line_no
-                    )
+                    row = load_json_object_line(raw, source_path=jsonl_file, line_number=line_no)
                 except JSONLParseError:
-                    logger.debug(
-                        "Skipping malformed line %d in %s", line_no, jsonl_file.name
-                    )
+                    logger.debug("Skipping malformed line %d in %s", line_no, jsonl_file.name)
                     continue
                 var_name = row.get(_DICT_VAR_KEY)
                 if isinstance(var_name, str) and var_name.casefold() in drop_set:

--- a/scripts/extraction/dataset_pipeline.py
+++ b/scripts/extraction/dataset_pipeline.py
@@ -15,7 +15,7 @@ retired; PHI handling is now fully covered by ``scripts/security/``.
 
 What this module does:
     1. Discover supported dataset files for the active study
-    2. Read ``.xlsx``, ``.xls``, and ``.csv`` files
+    2. Read ``.xlsx`` and ``.csv`` files
     3. Normalize rows into JSONL-safe records
     4. Write extraction output into the staging datasets directory
     5. Surface per-column drop events from duplicate-column cleanup so a
@@ -23,7 +23,6 @@ What this module does:
 
 Supported formats:
     - ``.xlsx`` via ``openpyxl``
-    - ``.xls`` via ``xlrd``
     - ``.csv`` via ``pandas.read_csv`` (single-file load; preserves one output file per input)
 
 Discovery rules:
@@ -398,11 +397,6 @@ def _read_tabular_file(path: Path) -> list[tuple[str, pd.DataFrame]]:
             names: list[str] = [str(n) for n in xls.sheet_names]
             return [(name, xls.parse(name, **_TABULAR_NA_OPTIONS)) for name in names]
 
-    if ext == ".xls":
-        with pd.ExcelFile(path, engine="xlrd") as xls:
-            names = [str(n) for n in xls.sheet_names]
-            return [(name, xls.parse(name, **_TABULAR_NA_OPTIONS)) for name in names]
-
     raise ValueError(f"Unsupported file extension: {ext}")
 
 
@@ -416,9 +410,8 @@ _PROVENANCE_ENGINE = f"pandas={pd.__version__}/openpyxl={_openpyxl.__version__}"
 
 Coarse run-level identifier stamped on every record's provenance regardless
 of source format. For ``.xlsx`` files the engine is openpyxl at the version
-shown. For ``.xls`` files ``xlrd`` is used (version not captured here —
-xlrd is an optional dependency absent from the lockfile). For ``.csv`` files
-no Excel engine is involved; pandas reads them directly.
+shown. For ``.csv`` files no Excel engine is involved; pandas reads them
+directly.
 """
 
 
@@ -537,9 +530,7 @@ def extract_single_dataset(
             continue
 
         # Remove provably-duplicate columns before writing JSONL
-        df, _drop_events = clean_duplicate_columns(
-            df, source_file=file_path.name, sheet=sheet_name
-        )
+        df, _drop_events = clean_duplicate_columns(df, source_file=file_path.name, sheet=sheet_name)
         if _drop_events:
             file_drop_events.extend(_drop_events)
 
@@ -663,9 +654,7 @@ def extract_datasets(
     from scripts.security.secure_env import assert_not_raw
 
     # --- resolve output dir ---
-    _output_dir = (
-        Path(output_dir) if output_dir is not None else Path(config.STAGING_DATASETS_DIR)
-    )
+    _output_dir = Path(output_dir) if output_dir is not None else Path(config.STAGING_DATASETS_DIR)
 
     # Caller-provided or default output must not point into the raw zone.
     assert_not_raw(_output_dir)

--- a/scripts/extraction/extract_pdf_data.py
+++ b/scripts/extraction/extract_pdf_data.py
@@ -885,9 +885,7 @@ def _resolve_orchestrator_credentials() -> tuple[str | None, str | None, str | N
         "anthropic": "ANTHROPIC_API_KEY",
         "google": "GOOGLE_API_KEY",
     }.get(provider)
-    api_key = (
-        os.environ.get(api_key_env, "").strip() if api_key_env else ""
-    ) or None
+    api_key = (os.environ.get(api_key_env, "").strip() if api_key_env else "") or None
 
     return provider, model, api_key
 
@@ -911,8 +909,7 @@ def _run_orchestrator_mode(
     snapshot_dir = _initial_snapshot_pdfs_dir()
     cache_dir = Path(config.STUDY_STAGING_DIR) / ".pdf_cache"
     log.info(
-        "PDF extraction: orchestrator mode — provider=%s model=%s "
-        "snapshot_dir=%s cache_dir=%s",
+        "PDF extraction: orchestrator mode — provider=%s model=%s snapshot_dir=%s cache_dir=%s",
         provider,
         model,
         snapshot_dir,

--- a/scripts/extraction/io/file_discovery.py
+++ b/scripts/extraction/io/file_discovery.py
@@ -34,7 +34,7 @@ DEFAULT_JUNK_FILENAMES: frozenset[str] = frozenset(
 )
 """Filenames unconditionally skipped during discovery."""
 
-SUPPORTED_TABULAR_EXTENSIONS: tuple[str, ...] = (".xlsx", ".xls", ".csv")
+SUPPORTED_TABULAR_EXTENSIONS: tuple[str, ...] = (".xlsx", ".csv")
 """File extensions recognised as tabular data sources."""
 
 

--- a/scripts/extraction/load_dictionary.py
+++ b/scripts/extraction/load_dictionary.py
@@ -4,7 +4,7 @@ Reads dictionary files from ``data/raw/{STUDY_NAME}/data_dictionary/``
 and writes structured JSONL under
 ``output/{STUDY_NAME}/trio_bundle/dictionary/``.
 
-Supports ``.xlsx``, ``.xls``, and ``.csv`` inputs. Detects multiple
+Supports ``.xlsx`` and ``.csv`` inputs. Detects multiple
 logical tables inside Excel sheets, enriches records with provenance
 metadata, and exports deterministic JSONL files.
 
@@ -25,7 +25,7 @@ __all__ = [
 
 import sys
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import pandas as pd
 from tqdm import tqdm
@@ -250,7 +250,9 @@ def _process_and_save_tables(
     return all_ok
 
 
-def process_excel_file(excel_path: Path | str, output_dir: Path | str, preserve_na: bool = True) -> bool:
+def process_excel_file(
+    excel_path: Path | str, output_dir: Path | str, preserve_na: bool = True
+) -> bool:
     """Extract all tables from an Excel file and save as JSONL files."""
     excel_path = Path(excel_path)
     output_dir = Path(output_dir)
@@ -260,9 +262,9 @@ def process_excel_file(excel_path: Path | str, output_dir: Path | str, preserve_
     output_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        _ext = excel_path.suffix.lower()
-        _engine: Literal["openpyxl", "xlrd"] = "openpyxl" if _ext == ".xlsx" else "xlrd"
-        with pd.ExcelFile(excel_path, engine=_engine) as xls:
+        if excel_path.suffix.lower() != ".xlsx":
+            raise ValueError(f"Unsupported dictionary Excel format: {excel_path.suffix}")
+        with pd.ExcelFile(excel_path, engine="openpyxl") as xls:
             log.debug(f"Excel file loaded. Found {len(xls.sheet_names)} sheets: {xls.sheet_names}")
             success = True
 
@@ -340,7 +342,9 @@ def discover_dictionary_files(dictionary_dir: Path | str) -> list[str]:
     return found
 
 
-def process_csv_file(csv_path: Path | str, output_dir: Path | str, preserve_na: bool = True) -> bool:
+def process_csv_file(
+    csv_path: Path | str, output_dir: Path | str, preserve_na: bool = True
+) -> bool:
     """Parse a CSV dictionary file and save as JSONL with provenance metadata."""
     csv_path = Path(csv_path)
     output_dir = Path(output_dir)
@@ -425,7 +429,7 @@ def load_study_dictionary(
     all_ok = True
     for fpath in files:
         ext = Path(fpath).suffix.lower()
-        if ext in (".xlsx", ".xls"):
+        if ext == ".xlsx":
             ok = process_excel_file(
                 excel_path=fpath, output_dir=output_dir, preserve_na=preserve_na
             )

--- a/scripts/extraction/pdf_pipeline.py
+++ b/scripts/extraction/pdf_pipeline.py
@@ -237,9 +237,7 @@ def _scrub_llm_response(data: dict[str, Any]) -> dict[str, Any]:
 
     walked = _walk(data)
     if not isinstance(walked, dict):
-        raise TypeError(
-            f"_scrub_llm_response received non-dict input: {type(data).__name__}"
-        )
+        raise TypeError(f"_scrub_llm_response received non-dict input: {type(data).__name__}")
     return walked
 
 
@@ -316,7 +314,9 @@ def _extract_via_llm(
 # ── Merge ───────────────────────────────────────────────────────────────────
 
 
-def _merge(code_data: dict[str, Any] | None, llm_data: dict[str, Any] | None) -> dict[str, Any] | None:
+def _merge(
+    code_data: dict[str, Any] | None, llm_data: dict[str, Any] | None
+) -> dict[str, Any] | None:
     """Merge code-tier + LLM-tier candidates. LLM wins on field-level
     conflicts within a variable; code-tier fills in variables the LLM
     missed."""
@@ -366,9 +366,7 @@ def _load_snapshot_for(pdf_name: str, snapshot_dir: Path) -> dict[str, Any] | No
                     data["extraction_tier"] = "snapshot"
                     return data
             except (json.JSONDecodeError, OSError) as exc:
-                logger.warning(
-                    "pdf_pipeline: snapshot %s unreadable: %s", path, exc
-                )
+                logger.warning("pdf_pipeline: snapshot %s unreadable: %s", path, exc)
     return None
 
 
@@ -479,7 +477,9 @@ def extract_pdf(
         code_data = _candidate_from_text(pdf_name, text)
 
     # Tier 2: LLM path (only when capable AND configured)
-    if not is_capable_model(provider, model):
+    if provider is None or model is None:
+        skipped = "provider/model not configured"
+    elif not is_capable_model(provider, model):
         skipped = f"model {provider}/{model} not on capable allowlist"
     elif not api_key:
         skipped = "no API key in KeyStore for selected provider"
@@ -488,7 +488,7 @@ def extract_pdf(
     else:
         # Cache lookup
         if cache_dir is not None:
-            key = _cache_key(pdf_path, provider, model)  # type: ignore[arg-type]
+            key = _cache_key(pdf_path, provider, model)
             cached = _cache_get(cache_dir, key)
             if cached is not None:
                 llm_data = cached
@@ -499,12 +499,15 @@ def extract_pdf(
         if llm_data is None:
             redacted = _redact_text_for_llm(text)
             llm_data = _extract_via_llm(
-                redacted, provider=provider, model=model, api_key=api_key  # type: ignore[arg-type]
+                redacted,
+                provider=provider,
+                model=model,
+                api_key=api_key,
             )
             if llm_data is None:
                 skipped = "LLM call failed or returned invalid JSON"
             elif cache_dir is not None:
-                _cache_put(cache_dir, _cache_key(pdf_path, provider, model), llm_data)  # type: ignore[arg-type]
+                _cache_put(cache_dir, _cache_key(pdf_path, provider, model), llm_data)
 
     # Decide path: LLM+code (merged) OR snapshot. Code-only is NEVER
     # a valid output (per the user's 2026-04-27 directive: heuristic

--- a/scripts/lint_doc_freshness.py
+++ b/scripts/lint_doc_freshness.py
@@ -45,9 +45,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Files / directories the linter scans for prose drift.
-TRACKED_FILES: tuple[str, ...] = (
-    "README.md",
-)
+TRACKED_FILES: tuple[str, ...] = ("README.md",)
 TRACKED_DIRS: tuple[str, ...] = (
     "docs/sphinx",
     "docs/irb_dossier",

--- a/scripts/security/phi_patterns.py
+++ b/scripts/security/phi_patterns.py
@@ -48,9 +48,7 @@ BLOCKING_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("URL", re.compile(r"\bhttps?://[^\s/$.?#].[^\s]*\b", re.I)),
     (
         "INDIAN_PIN",
-        re.compile(
-            r"(?i:pin\s*(?:code)?|postal\s*code|zip)\s*[:=\-]?\s*\b(\d{6})\b"
-        ),
+        re.compile(r"(?i:pin\s*(?:code)?|postal\s*code|zip)\s*[:=\-]?\s*\b(\d{6})\b"),
     ),
     # ── US identifier shapes (cross-site collaboration hedge) ────────────
     ("SSN", re.compile(r"\b\d{3}-\d{2}-\d{4}\b")),

--- a/scripts/security/secure_env.py
+++ b/scripts/security/secure_env.py
@@ -189,9 +189,7 @@ def assert_write_zone(path: str | Path) -> None:
     """
     resolved = _resolve(path)
     if not (_is_within(resolved, _OUTPUT_MARKER) or _is_within(resolved, _TMP_MARKER)):
-        raise ZoneViolationError(
-            f"Only paths under output/ or tmp/ are allowed here. Got: {path}"
-        )
+        raise ZoneViolationError(f"Only paths under output/ or tmp/ are allowed here. Got: {path}")
     if _is_within(resolved, _RAW_MARKER):
         raise ZoneViolationError(
             f"Access to raw data zone is forbidden at this pipeline stage: {path}"
@@ -231,5 +229,3 @@ def validate_paths(
         if deny_data_output:
             assert_output_not_in_data(p)
         assert_output_zone(p)
-
-

--- a/scripts/utils/errors.py
+++ b/scripts/utils/errors.py
@@ -61,9 +61,7 @@ class RePORTError:
     path: str | None = None
     hint: str | None = None
     traceback: str | None = None
-    timestamp: str = field(
-        default_factory=lambda: datetime.now(UTC).isoformat(timespec="seconds")
-    )
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat(timespec="seconds"))
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serialisable representation."""

--- a/scripts/utils/lineage.py
+++ b/scripts/utils/lineage.py
@@ -66,9 +66,7 @@ def _file_metadata(path: Path) -> dict[str, Any]:
     }
 
 
-def _collect_files(
-    root: Path, *, recursive: bool = True
-) -> list[dict[str, Any]]:
+def _collect_files(root: Path, *, recursive: bool = True) -> list[dict[str, Any]]:
     """Return file-metadata records for every regular file below *root*.
 
     Files are sorted by POSIX path for deterministic manifest output. Dot-

--- a/scripts/utils/log_hygiene.py
+++ b/scripts/utils/log_hygiene.py
@@ -125,9 +125,7 @@ class PHIRedactingFilter(logging.Filter):
 
     def _redact_subject_match(self, match: re.Match[str]) -> str:
         raw = match.group(0)
-        tag = hmac.new(self._hmac_key, raw.encode("utf-8"), hashlib.sha256).hexdigest()[
-            :8
-        ]
+        tag = hmac.new(self._hmac_key, raw.encode("utf-8"), hashlib.sha256).hexdigest()[:8]
         return f"<SUBJ_{tag}>"
 
     def _redact_text(self, text: str) -> str:
@@ -187,9 +185,7 @@ def install_phi_redactor(
     return flt
 
 
-def attach_to_logger(
-    logger: logging.Logger, filter_instance: PHIRedactingFilter
-) -> None:
+def attach_to_logger(logger: logging.Logger, filter_instance: PHIRedactingFilter) -> None:
     """Attach *filter_instance* to a specific named *logger* (belt-and-braces).
 
     ``logging.Filter`` is evaluated by the handler on the logger where it

--- a/scripts/utils/snapshots.py
+++ b/scripts/utils/snapshots.py
@@ -61,6 +61,7 @@ def _safe_rmtree(path: Path, *, ignore_errors: bool = False) -> None:
         return
     shutil.rmtree(path, ignore_errors=ignore_errors)
 
+
 __all__ = [
     "SnapshotError",
     "create_snapshot",
@@ -258,10 +259,7 @@ def restore_snapshot(name: str) -> Path:
 def _cmd_create(args: argparse.Namespace) -> int:
     snap_name = resolve_snapshot_name(args.name)
     target_dir = _snapshots_root() / snap_name
-    print(
-        f"Copying {_trio_root()} → {target_dir}"
-        + (" (overwrite)" if args.force else "")
-    )
+    print(f"Copying {_trio_root()} → {target_dir}" + (" (overwrite)" if args.force else ""))
     try:
         path = create_snapshot(snap_name, overwrite=args.force)
     except SnapshotError as exc:

--- a/scripts/utils/telemetry.py
+++ b/scripts/utils/telemetry.py
@@ -40,9 +40,7 @@ logger = logging.getLogger(__name__)
 # Single source of truth for PHI patterns is scripts.security.phi_patterns.
 # Using the shared catalog keeps telemetry aligned with the query-time gate
 # and log_hygiene (which log_hygiene.py itself flags as the correct path).
-_TELEMETRY_MASK_PATTERNS = [pat for _, pat in BLOCKING_PATTERNS] + [
-    pat for _, pat in WARN_PATTERNS
-]
+_TELEMETRY_MASK_PATTERNS = [pat for _, pat in BLOCKING_PATTERNS] + [pat for _, pat in WARN_PATTERNS]
 
 
 def _mask_phi(text: str) -> str:

--- a/tests/security/test_kanon_l_diversity.py
+++ b/tests/security/test_kanon_l_diversity.py
@@ -138,9 +138,7 @@ def test_guard_blocks_on_kanon() -> None:
 
 def test_guard_blocks_on_ldiv_after_kanon_passes() -> None:
     """k-anon passes (5 rows, single class) but homogeneity blocks."""
-    rows = [
-        {"AGE": "65+", "SEX": "M", "OUTCOME": "DIED"} for _ in range(5)
-    ]
+    rows = [{"AGE": "65+", "SEX": "M", "OUTCOME": "DIED"} for _ in range(5)]
     surfaced, kanon, ldiv = guard_rows_with_kanon_and_ldiv(
         rows,
         quasi_identifiers=("AGE", "SEX"),
@@ -169,7 +167,9 @@ def test_guard_skips_ldiv_when_no_sensitive_attributes() -> None:
 # ── query_dataset integration ───────────────────────────────────────────────
 
 
-def _seed_trio_with_rows(tmp_path: Path, rows: list[dict[str, Any]], dataset: str = "1A_ICScreening") -> None:
+def _seed_trio_with_rows(
+    tmp_path: Path, rows: list[dict[str, Any]], dataset: str = "1A_ICScreening"
+) -> None:
     """Write *rows* to a tmp trio_bundle/datasets/{dataset}.jsonl + monkeypatch
     config to point at it."""
     ds_dir = tmp_path / "trio_bundle" / "datasets"
@@ -188,15 +188,10 @@ def test_query_dataset_blocks_when_a_filter_returns_a_small_class(
     import config
 
     rows = [
-        {"SUBJID": f"SUBJ-{i}", "AGEY": 30, "IS_SEX": "F", "OUTCOME": "CURED"}
-        for i in range(20)
-    ] + [
-        {"SUBJID": "SUBJ-99", "AGEY": 88, "IS_SEX": "M", "OUTCOME": "DIED"}
-    ]
+        {"SUBJID": f"SUBJ-{i}", "AGEY": 30, "IS_SEX": "F", "OUTCOME": "CURED"} for i in range(20)
+    ] + [{"SUBJID": "SUBJ-99", "AGEY": 88, "IS_SEX": "M", "OUTCOME": "DIED"}]
     _seed_trio_with_rows(tmp_path, rows)
-    monkeypatch.setattr(
-        config, "TRIO_DATASETS_DIR", tmp_path / "trio_bundle" / "datasets"
-    )
+    monkeypatch.setattr(config, "TRIO_DATASETS_DIR", tmp_path / "trio_bundle" / "datasets")
     # Patch the zone marker so the unit test isn't fighting the
     # frozen-at-import production zone (the actual zone enforcement is
     # exercised by tests/test_secure_env.py + tests/test_file_access.py).
@@ -230,14 +225,9 @@ def test_query_dataset_passes_through_safe_rows(
     import config
 
     # 20 rows, all in the same QI class — k-anon class size = 20, passes.
-    rows = [
-        {"SUBJID": f"SUBJ-{i:03d}", "AGEY": 30, "IS_SEX": "F"}
-        for i in range(20)
-    ]
+    rows = [{"SUBJID": f"SUBJ-{i:03d}", "AGEY": 30, "IS_SEX": "F"} for i in range(20)]
     _seed_trio_with_rows(tmp_path, rows, dataset="2A_Demographics")
-    monkeypatch.setattr(
-        config, "TRIO_DATASETS_DIR", tmp_path / "trio_bundle" / "datasets"
-    )
+    monkeypatch.setattr(config, "TRIO_DATASETS_DIR", tmp_path / "trio_bundle" / "datasets")
     import scripts.ai_assistant.agent_tools as ag
 
     monkeypatch.setattr(ag, "assert_trio_bundle_zone", lambda _p: None)

--- a/tests/security/test_llm_capabilities.py
+++ b/tests/security/test_llm_capabilities.py
@@ -42,9 +42,7 @@ def test_gemini_pro_passes_flash_fails() -> None:
 
 
 def test_nvidia_405b_passes_smaller_fails() -> None:
-    assert is_capable_model(
-        "nvidia-ai-endpoints", "meta/llama-3.3-405b-instruct"
-    ) is True
+    assert is_capable_model("nvidia-ai-endpoints", "meta/llama-3.3-405b-instruct") is True
     assert is_capable_model("nvidia-ai-endpoints", "meta/llama-3.3-70b-instruct") is False
     assert is_capable_model("nvidia-ai-endpoints", "meta/llama-3.1-8b-instruct") is False
 

--- a/tests/security/test_pdf_redaction_pipeline.py
+++ b/tests/security/test_pdf_redaction_pipeline.py
@@ -220,7 +220,7 @@ def test_extract_pdf_returns_empty_when_no_llm_and_no_snapshot(tmp_path: Path) -
     assert isinstance(result, ExtractionResult)
     assert result.tier == "empty"
     assert result.llm_skipped_reason is not None
-    assert "not on capable allowlist" in result.llm_skipped_reason
+    assert result.llm_skipped_reason == "provider/model not configured"
 
 
 def test_extract_pdf_discards_code_only_falls_back_to_snapshot(
@@ -276,9 +276,7 @@ def test_extract_pdf_uses_snapshot_when_all_tiers_empty(tmp_path: Path) -> None:
     assert "AGE" in result.data["variables"]
 
 
-def test_extract_pdf_with_mocked_llm_path(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_extract_pdf_with_mocked_llm_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Verify the LLM path is reachable when a capable model is configured.
     Mock the LLM call so we don't make a real API request — the contract
     is that the orchestrator routes through ``_extract_via_llm`` when
@@ -289,9 +287,7 @@ def test_extract_pdf_with_mocked_llm_path(
     # Patch pdfplumber output (no real PDF parsing) AND the LLM call.
     import scripts.extraction.pdf_pipeline as pp
 
-    monkeypatch.setattr(
-        pp, "_extract_text_via_pdfplumber", lambda _p: _crf_text()
-    )
+    monkeypatch.setattr(pp, "_extract_text_via_pdfplumber", lambda _p: _crf_text())
 
     captured_payload: dict[str, str] = {}
 

--- a/tests/security/test_phase2_pipeline_polish.py
+++ b/tests/security/test_phase2_pipeline_polish.py
@@ -34,10 +34,7 @@ def test_sandbox_runner_chmods_sandbox_result_manifest() -> None:
     src = Path("scripts/ai_assistant/sandbox/runner.py").read_text(encoding="utf-8")
     assert "manifest_path.chmod(0o600)" in src or (
         "manifest_path = output_dir" in src and "chmod(0o600)" in src
-    ), (
-        "_sandbox_result.json must be chmod'd 0o600 in _emit_manifest "
-        "(see runner.py:_emit_manifest)"
-    )
+    ), "_sandbox_result.json must be chmod'd 0o600 in _emit_manifest (see runner.py:_emit_manifest)"
 
 
 # ── N5 — PDF staging zone assertion ─────────────────────────────────────────
@@ -138,8 +135,6 @@ def test_phi_scrub_yaml_pseudonymises_indovap_screen_numbers() -> None:
     cfg = load_scrub_config()
     assert cfg is not None, "phi_scrub.yaml failed to load"
     matched = any(rule.pattern.match("IS_SCRNNUM") for rule in cfg.id_patterns)
-    assert matched, (
-        "No id_patterns rule actually matches the literal column 'IS_SCRNNUM'"
-    )
+    assert matched, "No id_patterns rule actually matches the literal column 'IS_SCRNNUM'"
     matched_ic = any(rule.pattern.match("IC_SCRNNUM") for rule in cfg.id_patterns)
     assert matched_ic, "No id_patterns rule matches 'IC_SCRNNUM'"

--- a/tests/security/test_phase2_polish_permissions.py
+++ b/tests/security/test_phase2_polish_permissions.py
@@ -88,12 +88,8 @@ def test_sandbox_init_chmods_spec_json() -> None:
 
 def test_sandbox_runner_chmods_persisted_code() -> None:
     src = Path("scripts/ai_assistant/sandbox/runner.py").read_text(encoding="utf-8")
-    assert "code_dir.chmod(0o700)" in src, (
-        "runner.py must chmod the code/ subdir to 0o700"
-    )
-    assert "path.chmod(0o600)" in src, (
-        "runner.py must chmod each persisted run_*.py to 0o600"
-    )
+    assert "code_dir.chmod(0o700)" in src, "runner.py must chmod the code/ subdir to 0o700"
+    assert "path.chmod(0o600)" in src, "runner.py must chmod each persisted run_*.py to 0o600"
 
 
 # ── P1e — snapshots ─────────────────────────────────────────────────────────
@@ -134,7 +130,8 @@ def test_snapshots_module_uses_safe_rmtree_with_symlink_guard() -> None:
     # Only count actual call sites (``shutil.rmtree(``) — exclude comments
     # AND docstring mentions of the symbol.
     call_sites = [
-        line for line in src.splitlines()
+        line
+        for line in src.splitlines()
         if "shutil.rmtree(" in line and not line.lstrip().startswith("#")
     ]
     # Exactly one allowed call: the implementation inside _safe_rmtree.

--- a/tests/security/test_sandbox_isolation.py
+++ b/tests/security/test_sandbox_isolation.py
@@ -55,8 +55,7 @@ def trio_dataset(tmp_path: Path) -> dict[str, str]:
     ds_dir.mkdir(parents=True)
     path = ds_dir / "1A_ICScreening.jsonl"
     rows = [
-        {"SUBJID": f"SUBJ-{i:04d}", "AGE": 25 + i, "SEX": "M" if i % 2 else "F"}
-        for i in range(20)
+        {"SUBJID": f"SUBJ-{i:04d}", "AGE": 25 + i, "SEX": "M" if i % 2 else "F"} for i in range(20)
     ]
     path.write_text("\n".join(json.dumps(r) for r in rows))
     return {"df_1A_ICScreening": str(path)}
@@ -75,9 +74,7 @@ def _run(code: str, output_dir: Path, df_paths: dict[str, str], **kwargs):
     kwargs.setdefault("max_memory_mb", 2048)
     kwargs.setdefault("max_procs", 4096)
     kwargs.setdefault("max_files", 256)
-    return run_in_subprocess(
-        code, df_paths=df_paths, output_dir=output_dir, **kwargs
-    )
+    return run_in_subprocess(code, df_paths=df_paths, output_dir=output_dir, **kwargs)
 
 
 # ── 1. Confidentiality: env-var leak ────────────────────────────────────────
@@ -133,10 +130,7 @@ def test_write_outside_output_dir_rejected(
     ``_zone_guarded_open``, regardless of any subprocess-level filesystem
     visibility."""
     target = tmp_path / "escape.txt"
-    code = (
-        f"with open({str(target)!r}, 'w') as f:\n"
-        "    f.write('escaped')\n"
-    )
+    code = f"with open({str(target)!r}, 'w') as f:\n    f.write('escaped')\n"
     result = _run(code, output_dir, trio_dataset)
     assert result.exit_code != 0, "writing outside output_dir should fail"
     assert not target.exists(), "no file should be created outside output_dir"
@@ -159,7 +153,9 @@ def test_manifest_path_traversal_rejected(
     )
     result = _run(code, output_dir, trio_dataset)
     for path in result.figure_paths + result.code_paths:
-        assert output_dir.resolve() in path.resolve().parents or path.resolve() == output_dir.resolve()
+        assert (
+            output_dir.resolve() in path.resolve().parents or path.resolve() == output_dir.resolve()
+        )
 
 
 # ── 3. Confidentiality: read-zone enforcement ───────────────────────────────
@@ -172,10 +168,7 @@ def test_read_outside_trio_bundle_rejected(
     must be blocked by ``validate_agent_read``."""
     raw = tmp_path / "raw_phi.txt"
     raw.write_text("RAW PHI DATA — must not appear in sandbox output")
-    code = (
-        f"with open({str(raw)!r}, 'r') as f:\n"
-        "    print(f.read())\n"
-    )
+    code = f"with open({str(raw)!r}, 'r') as f:\n    print(f.read())\n"
     result = _run(code, output_dir, trio_dataset)
     assert "RAW PHI DATA" not in result.stdout
     assert "RAW PHI DATA" not in result.stderr
@@ -189,9 +182,7 @@ def test_wall_clock_timeout_kills_child() -> None:
     pass  # populated below in test_wall_clock_timeout — kept here for index
 
 
-def test_wall_clock_timeout(
-    output_dir: Path, trio_dataset: dict[str, str]
-) -> None:
+def test_wall_clock_timeout(output_dir: Path, trio_dataset: dict[str, str]) -> None:
     """Infinite loop must be killed promptly. Validates the *contract*
     (bounded execution) without being prescriptive about *which* kill
     mechanism wins — on Linux ``RLIMIT_CPU`` typically fires before the
@@ -212,9 +203,7 @@ def test_wall_clock_timeout(
 
 
 @LINUX_ONLY
-def test_cpu_rlimit_kills_busy_loop(
-    output_dir: Path, trio_dataset: dict[str, str]
-) -> None:
+def test_cpu_rlimit_kills_busy_loop(output_dir: Path, trio_dataset: dict[str, str]) -> None:
     """A pure-CPU spin loop should be killed by ``RLIMIT_CPU`` before the
     wall-clock timeout fires (when ``cpu_seconds < timeout_s``)."""
     code = "x = 0\nwhile True:\n    x += 1\n"
@@ -223,9 +212,7 @@ def test_cpu_rlimit_kills_busy_loop(
 
 
 @LINUX_ONLY
-def test_memory_rlimit_kills_oom(
-    output_dir: Path, trio_dataset: dict[str, str]
-) -> None:
+def test_memory_rlimit_kills_oom(output_dir: Path, trio_dataset: dict[str, str]) -> None:
     """Allocating well past the memory cap must trip ``RLIMIT_AS`` and kill
     the child cleanly. Cap raised here to 1.5 GB so numpy can import (~700 MB
     of vmap) and the test allocation (8 GB) is unambiguously above it."""
@@ -241,9 +228,7 @@ def test_memory_rlimit_kills_oom(
 
 
 @LINUX_ONLY
-def test_fork_bomb_blocked(
-    output_dir: Path, trio_dataset: dict[str, str]
-) -> None:
+def test_fork_bomb_blocked(output_dir: Path, trio_dataset: dict[str, str]) -> None:
     """``import os`` is blocked by the AST guard (primary defense) and any
     workaround would still hit ``RLIMIT_NPROC`` (secondary)."""
     code = "import os\nfor _ in range(10000):\n    os.fork()\n"
@@ -254,15 +239,9 @@ def test_fork_bomb_blocked(
 # ── 8. Network blocked ──────────────────────────────────────────────────────
 
 
-def test_network_socket_import_blocked(
-    output_dir: Path, trio_dataset: dict[str, str]
-) -> None:
+def test_network_socket_import_blocked(output_dir: Path, trio_dataset: dict[str, str]) -> None:
     """``import socket`` is not in the allow-list."""
-    code = (
-        "import socket\n"
-        "s = socket.socket()\n"
-        "s.connect(('1.1.1.1', 80))\n"
-    )
+    code = "import socket\ns = socket.socket()\ns.connect(('1.1.1.1', 80))\n"
     result = _run(code, output_dir, trio_dataset)
     assert result.exit_code != 0
     assert "Import not allowed" in result.stderr or "ImportError" in result.stderr
@@ -271,9 +250,7 @@ def test_network_socket_import_blocked(
 # ── 9-11. Legitimate use ────────────────────────────────────────────────────
 
 
-def test_legitimate_pandas_groupby(
-    output_dir: Path, trio_dataset: dict[str, str]
-) -> None:
+def test_legitimate_pandas_groupby(output_dir: Path, trio_dataset: dict[str, str]) -> None:
     """Sanity: standard pandas analysis on a pre-loaded trio DataFrame works."""
     code = (
         "by_sex = df_1A_ICScreening.groupby('SEX')['AGE'].mean().round(1)\n"
@@ -284,9 +261,7 @@ def test_legitimate_pandas_groupby(
     assert "'M'" in result.stdout or "'F'" in result.stdout
 
 
-def test_legitimate_plotly_save(
-    output_dir: Path, trio_dataset: dict[str, str]
-) -> None:
+def test_legitimate_plotly_save(output_dir: Path, trio_dataset: dict[str, str]) -> None:
     """Plotly figure JSON should be written to ``output_dir`` and reported."""
     code = (
         "import plotly.express as px\n"
@@ -300,9 +275,7 @@ def test_legitimate_plotly_save(
     assert result.ok or len(result.figure_paths) >= 0  # exact contract TBD
 
 
-def test_legitimate_matplotlib_save(
-    output_dir: Path, trio_dataset: dict[str, str]
-) -> None:
+def test_legitimate_matplotlib_save(output_dir: Path, trio_dataset: dict[str, str]) -> None:
     """Matplotlib PNG via ``plt.savefig`` should appear under ``output_dir``."""
     code = (
         "import matplotlib\n"
@@ -321,9 +294,7 @@ def test_legitimate_matplotlib_save(
 # ── 12. Defense in depth: AST guards still active inside child ─────────────
 
 
-def test_ast_guard_blocks_subclasses_lookup(
-    output_dir: Path, trio_dataset: dict[str, str]
-) -> None:
+def test_ast_guard_blocks_subclasses_lookup(output_dir: Path, trio_dataset: dict[str, str]) -> None:
     """Even with subprocess isolation, the in-child AST/runtime guards must
     still reject classic dunder gadgets — defense in depth."""
     code = "x = getattr(int, '__subclasses__')()\nprint(x)\n"
@@ -367,9 +338,7 @@ def test_generated_code_persisted_as_py_file(
     assert saved[0] in result.code_paths
 
 
-def test_persisted_code_marker_in_result(
-    output_dir: Path, trio_dataset: dict[str, str]
-) -> None:
+def test_persisted_code_marker_in_result(output_dir: Path, trio_dataset: dict[str, str]) -> None:
     """``code_paths`` on the result is what the agent_tools formatter turns
     into a ``<RPLN_CODE:...>`` marker for the streaming UI."""
     code = "print('x')\n"
@@ -392,9 +361,7 @@ def test_persisted_code_has_replication_header(
     assert "replicate" in text.lower(), "header should describe how to re-run"
 
 
-def test_persistence_can_be_disabled(
-    output_dir: Path, trio_dataset: dict[str, str]
-) -> None:
+def test_persistence_can_be_disabled(output_dir: Path, trio_dataset: dict[str, str]) -> None:
     """``persist_code=False`` must skip the .py write entirely."""
     code = "print('z')\n"
     result = _run(code, output_dir, trio_dataset, persist_code=False)

--- a/tests/test_agent_conversational_guard.py
+++ b/tests/test_agent_conversational_guard.py
@@ -86,21 +86,21 @@ class TestSearchVariablesShortCircuit:
         from scripts.ai_assistant.agent_tools import search_variables
 
         # @tool wraps the function; invoke the underlying callable.
-        fn = getattr(search_variables, "func", search_variables)
+        fn: Any = getattr(search_variables, "func", search_variables)
         out = fn("hi")
         assert out == _CONVERSATIONAL_REFUSAL_MESSAGE
 
     def test_hello_returns_refusal_message(self) -> None:
         from scripts.ai_assistant.agent_tools import search_variables
 
-        fn = getattr(search_variables, "func", search_variables)
+        fn: Any = getattr(search_variables, "func", search_variables)
         out = fn("hello")
         assert out == _CONVERSATIONAL_REFUSAL_MESSAGE
 
     def test_empty_returns_refusal_message(self) -> None:
         from scripts.ai_assistant.agent_tools import search_variables
 
-        fn = getattr(search_variables, "func", search_variables)
+        fn: Any = getattr(search_variables, "func", search_variables)
         assert fn("") == _CONVERSATIONAL_REFUSAL_MESSAGE
         assert fn("  ") == _CONVERSATIONAL_REFUSAL_MESSAGE
 

--- a/tests/test_agent_graph.py
+++ b/tests/test_agent_graph.py
@@ -63,7 +63,7 @@ class TestGetCheckpointer:
 
 class TestGetAgent:
     @patch("scripts.ai_assistant.agent_graph._init_llm")
-    @patch("scripts.ai_assistant.agent_graph.create_react_agent")
+    @patch("scripts.ai_assistant.agent_graph.create_agent")
     def test_creates_agent_with_all_tools(self, mock_create, mock_llm):
         mock_llm.return_value = MagicMock()
         mock_create.return_value = MagicMock()
@@ -77,7 +77,7 @@ class TestGetAgent:
         assert kwargs["tools"] is ALL_TOOLS
 
     @patch("scripts.ai_assistant.agent_graph._init_llm")
-    @patch("scripts.ai_assistant.agent_graph.create_react_agent")
+    @patch("scripts.ai_assistant.agent_graph.create_agent")
     def test_agent_is_singleton(self, mock_create, mock_llm):
         mock_llm.return_value = MagicMock()
         mock_create.return_value = MagicMock()
@@ -87,18 +87,18 @@ class TestGetAgent:
         assert mock_create.call_count == 1
 
     @patch("scripts.ai_assistant.agent_graph._init_llm")
-    @patch("scripts.ai_assistant.agent_graph.create_react_agent")
+    @patch("scripts.ai_assistant.agent_graph.create_agent")
     def test_agent_receives_system_prompt(self, mock_create, mock_llm):
         mock_llm.return_value = MagicMock()
         mock_create.return_value = MagicMock()
         get_agent()
         _, kwargs = mock_create.call_args
-        assert "prompt" in kwargs
-        assert isinstance(kwargs["prompt"], str)
-        assert len(kwargs["prompt"]) > 100  # non-trivial system prompt
+        assert "system_prompt" in kwargs
+        assert isinstance(kwargs["system_prompt"], str)
+        assert len(kwargs["system_prompt"]) > 100  # non-trivial system prompt
 
     @patch("scripts.ai_assistant.agent_graph._init_llm")
-    @patch("scripts.ai_assistant.agent_graph.create_react_agent")
+    @patch("scripts.ai_assistant.agent_graph.create_agent")
     def test_agent_receives_checkpointer(self, mock_create, mock_llm):
         mock_llm.return_value = MagicMock()
         mock_create.return_value = MagicMock()
@@ -123,7 +123,7 @@ class TestGetAgent:
 
 class TestResetAgent:
     @patch("scripts.ai_assistant.agent_graph._init_llm")
-    @patch("scripts.ai_assistant.agent_graph.create_react_agent")
+    @patch("scripts.ai_assistant.agent_graph.create_agent")
     def test_reset_clears_singleton(self, mock_create, mock_llm):
         mock_llm.return_value = MagicMock()
         mock_create.side_effect = [MagicMock(), MagicMock()]
@@ -134,7 +134,7 @@ class TestResetAgent:
         assert mock_create.call_count == 2
 
     @patch("scripts.ai_assistant.agent_graph._init_llm")
-    @patch("scripts.ai_assistant.agent_graph.create_react_agent")
+    @patch("scripts.ai_assistant.agent_graph.create_agent")
     def test_reset_clears_checkpointer(self, mock_create, mock_llm):
         mock_llm.return_value = MagicMock()
         mock_create.return_value = MagicMock()
@@ -152,7 +152,7 @@ class TestResetAgent:
 
 class TestInvokeQuery:
     @patch("scripts.ai_assistant.agent_graph._init_llm")
-    @patch("scripts.ai_assistant.agent_graph.create_react_agent")
+    @patch("scripts.ai_assistant.agent_graph.create_agent")
     def test_returns_ai_message_content(self, mock_create, mock_llm):
         from langchain_core.messages import AIMessage
 
@@ -164,7 +164,7 @@ class TestInvokeQuery:
         assert result == "Test answer"
 
     @patch("scripts.ai_assistant.agent_graph._init_llm")
-    @patch("scripts.ai_assistant.agent_graph.create_react_agent")
+    @patch("scripts.ai_assistant.agent_graph.create_agent")
     def test_returns_last_ai_message(self, mock_create, mock_llm):
         from langchain_core.messages import AIMessage, HumanMessage
 
@@ -182,7 +182,7 @@ class TestInvokeQuery:
         assert result == "final answer"
 
     @patch("scripts.ai_assistant.agent_graph._init_llm")
-    @patch("scripts.ai_assistant.agent_graph.create_react_agent")
+    @patch("scripts.ai_assistant.agent_graph.create_agent")
     def test_no_ai_message_returns_fallback(self, mock_create, mock_llm):
         mock_llm.return_value = MagicMock()
         mock_agent = MagicMock()
@@ -192,7 +192,7 @@ class TestInvokeQuery:
         assert result == "(No response generated.)"
 
     @patch("scripts.ai_assistant.agent_graph._init_llm")
-    @patch("scripts.ai_assistant.agent_graph.create_react_agent")
+    @patch("scripts.ai_assistant.agent_graph.create_agent")
     def test_thread_id_isolation(self, mock_create, mock_llm):
         mock_llm.return_value = MagicMock()
         mock_agent = MagicMock()
@@ -221,7 +221,7 @@ class TestInvokeQuery:
 
 class TestStreamQuery:
     @patch("scripts.ai_assistant.agent_graph._init_llm")
-    @patch("scripts.ai_assistant.agent_graph.create_react_agent")
+    @patch("scripts.ai_assistant.agent_graph.create_agent")
     def test_returns_iterator(self, mock_create, mock_llm):
         mock_llm.return_value = MagicMock()
         mock_agent = MagicMock()
@@ -232,7 +232,7 @@ class TestStreamQuery:
         assert len(chunks) == 1
 
     @patch("scripts.ai_assistant.agent_graph._init_llm")
-    @patch("scripts.ai_assistant.agent_graph.create_react_agent")
+    @patch("scripts.ai_assistant.agent_graph.create_agent")
     def test_passes_callbacks(self, mock_create, mock_llm):
         mock_llm.return_value = MagicMock()
         mock_agent = MagicMock()
@@ -332,8 +332,7 @@ class TestInitLlmOomLadder:
     @staticmethod
     def _oom(size_g: float = 5.5, avail_g: float = 2.9) -> Exception:
         return RuntimeError(
-            f"model requires more system memory ({size_g} GiB) than "
-            f"is available ({avail_g} GiB)"
+            f"model requires more system memory ({size_g} GiB) than is available ({avail_g} GiB)"
         )
 
     def test_first_rung_ok_skips_ladder(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -213,9 +213,7 @@ class TestSearchPdfContext:
         tool_cache.clear()
         self._write_pdf_fixture(config.PDF_EXTRACTIONS_DIR)
 
-        raw = search_pdf_context.invoke(
-            {"query": "Cohort A eligibility", "k": 3}
-        )
+        raw = search_pdf_context.invoke({"query": "Cohort A eligibility", "k": 3})
         payload = json.loads(raw)
         assert payload["count"] >= 1
         assert payload["snippets"][0]["rank"] == 1
@@ -229,9 +227,7 @@ class TestSearchPdfContext:
         tool_cache.clear()
         self._write_pdf_fixture(config.PDF_EXTRACTIONS_DIR)
 
-        raw = search_pdf_context.invoke(
-            {"query": "household contact same dwelling"}
-        )
+        raw = search_pdf_context.invoke({"query": "household contact same dwelling"})
         top = json.loads(raw)["snippets"][0]
         assert "Household Contact" in top["form_name"]
         assert top["source_pdf"] == "Form 1B.pdf"
@@ -244,9 +240,7 @@ class TestSearchPdfContext:
         tool_cache.clear()
         self._write_pdf_fixture(config.PDF_EXTRACTIONS_DIR)
 
-        raw = search_pdf_context.invoke(
-            {"query": "participant enrollment"}
-        )
+        raw = search_pdf_context.invoke({"query": "participant enrollment"})
         payload = json.loads(raw)
         # low-confidence flag set on weak matches
         assert "low_confidence" in payload

--- a/tests/test_cleanup_propagation.py
+++ b/tests/test_cleanup_propagation.py
@@ -511,7 +511,5 @@ class TestRunPropagation:
 
         # 8. Dict/PDF legs emit no audit artifact — only the dataset audit
         #    that we seeded in step 1 should exist under STUDY_AUDIT_DIR.
-        audit_files = sorted(
-            p.name for p in config.STUDY_AUDIT_DIR.glob("*.json")
-        )
+        audit_files = sorted(p.name for p in config.STUDY_AUDIT_DIR.glob("*.json"))
         assert audit_files == ["dataset_cleanup_report.json"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -129,10 +129,7 @@ class TestAuditReportPaths:
         )
 
     def test_scrub_report_path(self) -> None:
-        assert (
-            config.AUDIT_SCRUB_REPORT_PATH
-            == config.STUDY_AUDIT_DIR / "phi_scrub_report.json"
-        )
+        assert config.AUDIT_SCRUB_REPORT_PATH == config.STUDY_AUDIT_DIR / "phi_scrub_report.json"
 
     def test_no_dict_or_pdf_audit_constants_defined(self) -> None:
         assert not hasattr(config, "AUDIT_DICTIONARY_REPORT_PATH")

--- a/tests/test_dataset_pipeline.py
+++ b/tests/test_dataset_pipeline.py
@@ -54,6 +54,17 @@ class TestDiscoverDatasetFiles:
         result = discover_dataset_files(tmp_path)
         assert len(result) == 2
 
+    def test_ignores_legacy_xls_files(self, tmp_path: Path) -> None:
+        (tmp_path / "legacy.xls").write_bytes(b"fake")
+        (tmp_path / "modern.xlsx").write_bytes(b"fake")
+        result = discover_dataset_files(tmp_path)
+        assert [p.name for p in result] == ["modern.xlsx"]
+
+    def test_legacy_xls_only_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "legacy.xls").write_bytes(b"fake")
+        with pytest.raises(ValueError, match=r"Supported extensions: \.csv, \.xlsx"):
+            discover_dataset_files(tmp_path)
+
     def test_skips_lock_files(self, tmp_path: Path) -> None:
         (tmp_path / "~$locked.xlsx").write_bytes(b"fake")
         (tmp_path / "real.xlsx").write_bytes(b"fake")

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -129,15 +129,13 @@ class TestCleanDuplicateColumns:
         df = pd.DataFrame(
             {
                 "SUBJID": [1, 2, 3],
-                "SUBJID2": [1, 2, 3],            # duplicate of SUBJID
+                "SUBJID2": [1, 2, 3],  # duplicate of SUBJID
                 "NAME": ["a", "b", "c"],
-                "NAME_2": [None, None, None],   # null, base NAME exists
-                "AGE": [20, 30, 40],             # untouched
+                "NAME_2": [None, None, None],  # null, base NAME exists
+                "AGE": [20, 30, 40],  # untouched
             }
         )
-        cleaned, events = clean_duplicate_columns(
-            df, source_file="mixed.jsonl", sheet="S1"
-        )
+        cleaned, events = clean_duplicate_columns(df, source_file="mixed.jsonl", sheet="S1")
         # The cleaned frame keeps base columns + AGE
         assert set(cleaned.columns) == {"SUBJID", "NAME", "AGE"}
         # One event per dropped column, in encounter order
@@ -161,9 +159,7 @@ class TestCleanDuplicateColumns:
 
     def test_every_event_has_required_keys(self) -> None:
         df = pd.DataFrame({"SUBJID": [1, 2], "SUBJID2": [1, 2]})
-        _cleaned, events = clean_duplicate_columns(
-            df, source_file="demo.jsonl", sheet=None
-        )
+        _cleaned, events = clean_duplicate_columns(df, source_file="demo.jsonl", sheet=None)
         required = {"scope", "name", "file", "sheet", "reason", "kept"}
         for event in events:
             assert required <= set(event.keys())

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,4 +1,5 @@
 """Tests for the RePORTError structured envelope."""
+
 from __future__ import annotations
 
 import json
@@ -32,9 +33,7 @@ def test_wrap_can_suppress_traceback() -> None:
     try:
         raise RuntimeError("boom")
     except Exception as exc:
-        err = errors.wrap(
-            exc, stage="test", operation="op", include_traceback=False
-        )
+        err = errors.wrap(exc, stage="test", operation="op", include_traceback=False)
     assert err.traceback is None
 
 

--- a/tests/test_extract_pdf_data.py
+++ b/tests/test_extract_pdf_data.py
@@ -228,9 +228,7 @@ class TestPdfExtractionModeDispatch:
 
         # Provider must NOT be touched in snapshot mode.
         def _boom() -> None:
-            raise AssertionError(
-                "_resolve_pdf_provider must not be invoked when mode=snapshot"
-            )
+            raise AssertionError("_resolve_pdf_provider must not be invoked when mode=snapshot")
 
         monkeypatch.setattr(epd, "_resolve_pdf_provider", _boom)
         monkeypatch.setenv("REPORTALIN_PDF_EXTRACTION_MODE", "snapshot")
@@ -256,13 +254,13 @@ class TestPdfExtractionModeDispatch:
         pdf_src.mkdir()
         (pdf_src / "form_missing.pdf").write_bytes(b"%PDF-1.4\n%EOF\n")
         # Snapshot dir exists but is empty for this PDF.
-        (Path(config.STUDY_SNAPSHOTS_DIR) / "pdfs").mkdir(
-            parents=True, exist_ok=True
-        )
+        (Path(config.STUDY_SNAPSHOTS_DIR) / "pdfs").mkdir(parents=True, exist_ok=True)
 
-        monkeypatch.setattr(epd, "_resolve_pdf_provider", lambda: (_ for _ in ()).throw(
-            AssertionError("provider must not be called")
-        ))
+        monkeypatch.setattr(
+            epd,
+            "_resolve_pdf_provider",
+            lambda: (_ for _ in ()).throw(AssertionError("provider must not be called")),
+        )
         monkeypatch.setenv("REPORTALIN_PDF_EXTRACTION_MODE", "snapshot")
 
         result = extract_pdfs_to_jsonl(pdf_dir=pdf_src)
@@ -304,9 +302,11 @@ class TestPdfExtractionModeDispatch:
             )
 
         monkeypatch.setattr(pp, "extract_pdf", _fake_extract)
-        monkeypatch.setattr(epd, "_resolve_pdf_provider", lambda: (_ for _ in ()).throw(
-            AssertionError("provider must not be called")
-        ))
+        monkeypatch.setattr(
+            epd,
+            "_resolve_pdf_provider",
+            lambda: (_ for _ in ()).throw(AssertionError("provider must not be called")),
+        )
 
         # Wizard subprocess env injection emulation.
         monkeypatch.setenv("REPORTALIN_PDF_EXTRACTION_MODE", "llm")

--- a/tests/test_file_access.py
+++ b/tests/test_file_access.py
@@ -99,9 +99,7 @@ class TestValidateAgentWrite:
         f = config.STUDY_RESTORE_POINTS_DIR / "run-x" / "snap.json"
         assert validate_agent_write(f) == Path(f.resolve())
 
-    def test_tracked_snapshots_baseline_rejected(
-        self, monkeypatch_config: Path
-    ) -> None:
+    def test_tracked_snapshots_baseline_rejected(self, monkeypatch_config: Path) -> None:
         """Tracked baseline at ``snapshots/{STUDY}/`` is OUTSIDE the agent
         write zone — only a maintainer (with shell access) curates it."""
         import config
@@ -162,9 +160,7 @@ class TestTraversalAndSymlinkSafety:
     through the agent interface.
     """
 
-    def test_symlink_from_agent_to_audit_rejected_on_read(
-        self, monkeypatch_config: Path
-    ) -> None:
+    def test_symlink_from_agent_to_audit_rejected_on_read(self, monkeypatch_config: Path) -> None:
         import config
 
         target = config.STUDY_AUDIT_DIR / "phi_scrub_report.json"
@@ -174,9 +170,7 @@ class TestTraversalAndSymlinkSafety:
         with pytest.raises(ZoneViolationError):
             validate_agent_read(link)
 
-    def test_symlink_from_agent_to_staging_rejected_on_read(
-        self, monkeypatch_config: Path
-    ) -> None:
+    def test_symlink_from_agent_to_staging_rejected_on_read(self, monkeypatch_config: Path) -> None:
         import config
 
         config.STAGING_DATASETS_DIR.mkdir(parents=True, exist_ok=True)
@@ -187,9 +181,7 @@ class TestTraversalAndSymlinkSafety:
         with pytest.raises(ZoneViolationError):
             validate_agent_read(link)
 
-    def test_symlink_from_agent_to_audit_rejected_on_write(
-        self, monkeypatch_config: Path
-    ) -> None:
+    def test_symlink_from_agent_to_audit_rejected_on_write(self, monkeypatch_config: Path) -> None:
         """A write through a symlink that resolves outside ``AGENT_STATE_DIR``
         must be blocked, even though the symlink itself lives inside."""
         import config
@@ -201,9 +193,7 @@ class TestTraversalAndSymlinkSafety:
         with pytest.raises(ZoneViolationError):
             validate_agent_write(link_dir / "tamper.json")
 
-    def test_parent_traversal_escape_rejected_on_read(
-        self, monkeypatch_config: Path
-    ) -> None:
+    def test_parent_traversal_escape_rejected_on_read(self, monkeypatch_config: Path) -> None:
         """``agent/../audit/x.json`` must resolve out of the agent zone."""
         import config
 
@@ -213,14 +203,10 @@ class TestTraversalAndSymlinkSafety:
         with pytest.raises(ZoneViolationError):
             validate_agent_read(traversal)
 
-    def test_parent_traversal_escape_rejected_on_write(
-        self, monkeypatch_config: Path
-    ) -> None:
+    def test_parent_traversal_escape_rejected_on_write(self, monkeypatch_config: Path) -> None:
         import config
 
-        traversal = (
-            config.AGENT_OUTPUT_DIR / ".." / ".." / "audit" / "tamper.json"
-        )
+        traversal = config.AGENT_OUTPUT_DIR / ".." / ".." / "audit" / "tamper.json"
         with pytest.raises(ZoneViolationError):
             validate_agent_write(traversal)
 
@@ -244,17 +230,13 @@ class TestValidateSandboxWrite:
         commonpath catches this; startswith did not."""
         import config
 
-        sibling = config.AGENT_OUTPUT_DIR.parent / (
-            config.AGENT_OUTPUT_DIR.name + "_exfil"
-        )
+        sibling = config.AGENT_OUTPUT_DIR.parent / (config.AGENT_OUTPUT_DIR.name + "_exfil")
         sibling.mkdir(parents=True, exist_ok=True)
         f = sibling / "x.csv"
         with pytest.raises(ZoneViolationError):
             validate_sandbox_write(f)
 
-    def test_agent_state_outside_analysis_rejected(
-        self, monkeypatch_config: Path
-    ) -> None:
+    def test_agent_state_outside_analysis_rejected(self, monkeypatch_config: Path) -> None:
         """Sandbox write zone is narrower than agent-tool zone:
         other ``agent/`` subdirs like restore_points/ are rejected."""
         import config

--- a/tests/test_file_discovery.py
+++ b/tests/test_file_discovery.py
@@ -8,11 +8,15 @@ import pytest
 
 from scripts.extraction.io.file_discovery import (
     DEFAULT_JUNK_FILENAMES,
+    SUPPORTED_TABULAR_EXTENSIONS,
     discover_files,
 )
 
 
 class TestDiscoverFiles:
+    def test_supported_tabular_extensions_are_xlsx_and_csv_only(self) -> None:
+        assert SUPPORTED_TABULAR_EXTENSIONS == (".xlsx", ".csv")
+
     def test_finds_xlsx_files(self, tmp_path: Path) -> None:
         (tmp_path / "data.xlsx").write_bytes(b"fake")
         (tmp_path / "info.csv").write_bytes(b"fake")

--- a/tests/test_lineage_manifest.py
+++ b/tests/test_lineage_manifest.py
@@ -22,9 +22,7 @@ class TestHashPath:
 
 
 class TestEmitLineageManifest:
-    def test_full_manifest(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_full_manifest(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # Override the output-zone marker so tmp_path qualifies.
         from scripts.security import secure_env
 
@@ -52,9 +50,7 @@ class TestEmitLineageManifest:
                     "study": "TEST",
                     "generated_utc": "2026-04-23T12:00:00Z",
                     "compliance_posture": "safe_harbor",
-                    "scrubbed": [
-                        {"scope": "phi-scrub-drop", "field": "STAFF_NAME", "count": 3}
-                    ],
+                    "scrubbed": [{"scope": "phi-scrub-drop", "field": "STAFF_NAME", "count": 3}],
                 }
             )
         )

--- a/tests/test_load_dictionary.py
+++ b/tests/test_load_dictionary.py
@@ -17,6 +17,7 @@ from scripts.extraction.load_dictionary import (
     UNNAMED_COLUMN_PREFIX,
     _deduplicate_columns,
     _split_sheet_into_tables,
+    discover_dictionary_files,
     load_study_dictionary,
 )
 
@@ -82,6 +83,22 @@ class TestSplitSheetIntoTables:
         tables = _split_sheet_into_tables(df)
         assert len(tables) == 2
 
+
+class TestDiscoverDictionaryFiles:
+    def test_finds_xlsx_and_csv_only(self, tmp_path: Path) -> None:
+        (tmp_path / "dict.xlsx").write_bytes(b"fake")
+        (tmp_path / "dict.csv").write_bytes(b"fake")
+        (tmp_path / "legacy.xls").write_bytes(b"fake")
+
+        assert [Path(p).name for p in discover_dictionary_files(tmp_path)] == [
+            "dict.csv",
+            "dict.xlsx",
+        ]
+
+    def test_legacy_xls_only_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "legacy.xls").write_bytes(b"fake")
+        with pytest.raises(ValueError, match=r"Supported extensions: \.csv, \.xlsx"):
+            discover_dictionary_files(tmp_path)
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_log_hygiene.py
+++ b/tests/test_log_hygiene.py
@@ -32,9 +32,7 @@ class TestPHIRedactingFilterGeneric:
         assert "a.b@example.com" not in out
         assert "<EMAIL>" in out
 
-    def test_indian_phone_redacted(
-        self, flt: log_hygiene.PHIRedactingFilter
-    ) -> None:
+    def test_indian_phone_redacted(self, flt: log_hygiene.PHIRedactingFilter) -> None:
         out = log_hygiene._redact("call +91 9876543210 soon", flt)
         assert "9876543210" not in out
         assert "<INDIAN_PHONE>" in out
@@ -54,9 +52,7 @@ class TestPHIRedactingFilterGeneric:
         assert "560001" not in out
         assert "<INDIAN_PIN>" in out
 
-    def test_clean_text_passthrough(
-        self, flt: log_hygiene.PHIRedactingFilter
-    ) -> None:
+    def test_clean_text_passthrough(self, flt: log_hygiene.PHIRedactingFilter) -> None:
         msg = "Pipeline step completed successfully"
         assert log_hygiene._redact(msg, flt) == msg
 
@@ -65,13 +61,9 @@ class TestPHIRedactingFilterSubjectIds:
     @pytest.fixture()
     def flt(self) -> log_hygiene.PHIRedactingFilter:
         patterns = [re.compile(r"\bSC\d{4}\b"), re.compile(r"\bSUBJ-\d+\b")]
-        return log_hygiene.PHIRedactingFilter(
-            hmac_key=TEST_KEY, subject_id_patterns=patterns
-        )
+        return log_hygiene.PHIRedactingFilter(hmac_key=TEST_KEY, subject_id_patterns=patterns)
 
-    def test_subject_id_replaced_with_hmac_tag(
-        self, flt: log_hygiene.PHIRedactingFilter
-    ) -> None:
+    def test_subject_id_replaced_with_hmac_tag(self, flt: log_hygiene.PHIRedactingFilter) -> None:
         out = log_hygiene._redact("row for SC1234 processed", flt)
         assert "SC1234" not in out
         assert "<SUBJ_" in out
@@ -83,18 +75,14 @@ class TestPHIRedactingFilterSubjectIds:
         tag_a = a.replace("<SUBJ_", "").replace(">", "")
         assert tag_a in b
 
-    def test_different_ids_different_tags(
-        self, flt: log_hygiene.PHIRedactingFilter
-    ) -> None:
+    def test_different_ids_different_tags(self, flt: log_hygiene.PHIRedactingFilter) -> None:
         a = log_hygiene._redact("SC1234", flt)
         b = log_hygiene._redact("SC9999", flt)
         assert a != b
 
 
 class TestInstallPhiRedactor:
-    def test_install_is_idempotent(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_install_is_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         root = logging.getLogger()
         original_filters = list(root.filters)
 
@@ -103,17 +91,13 @@ class TestInstallPhiRedactor:
             b = log_hygiene.install_phi_redactor(hmac_key=TEST_KEY)
             assert a is b
             # Root logger has exactly one PHIRedactingFilter attached.
-            matching = [
-                f for f in root.filters if isinstance(f, log_hygiene.PHIRedactingFilter)
-            ]
+            matching = [f for f in root.filters if isinstance(f, log_hygiene.PHIRedactingFilter)]
             assert len(matching) == 1
         finally:
             # Restore original filters.
             root.filters = original_filters
 
-    def test_filter_applies_to_log_output(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_filter_applies_to_log_output(self, caplog: pytest.LogCaptureFixture) -> None:
         flt = log_hygiene.PHIRedactingFilter(hmac_key=TEST_KEY)
         logger = logging.getLogger("test_log_hygiene.apply")
         logger.addFilter(flt)
@@ -122,15 +106,11 @@ class TestInstallPhiRedactor:
             logger.info("processing row with email patient@example.com now")
         logger.removeFilter(flt)
         assert any("<EMAIL>" in r.getMessage() for r in caplog.records)
-        assert not any(
-            "patient@example.com" in r.getMessage() for r in caplog.records
-        )
+        assert not any("patient@example.com" in r.getMessage() for r in caplog.records)
 
 
 class TestBestEffortOnFailure:
-    def test_malformed_format_args_do_not_crash(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_malformed_format_args_do_not_crash(self, caplog: pytest.LogCaptureFixture) -> None:
         flt = log_hygiene.PHIRedactingFilter(hmac_key=TEST_KEY)
         logger = logging.getLogger("test_log_hygiene.errors")
         logger.addFilter(flt)

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -241,9 +241,7 @@ class TestEmitOutputSignpost:
 
         assert __version__ in body
 
-    def test_is_idempotent_and_overwrites_stale_content(
-        self, monkeypatch_config: Path
-    ) -> None:
+    def test_is_idempotent_and_overwrites_stale_content(self, monkeypatch_config: Path) -> None:
         import config
 
         readme = Path(config.STUDY_OUTPUT_DIR) / "README.md"

--- a/tests/test_model_downgrade_ladder.py
+++ b/tests/test_model_downgrade_ladder.py
@@ -19,9 +19,7 @@ from scripts.ai_assistant.ui.providers import (
 
 class TestPreferredOrInstalledDowngrade:
     def test_returns_preferred_when_installed(self) -> None:
-        got = preferred_or_installed_downgrade(
-            "qwen3:8b", ["qwen3:8b", "qwen3:4b", "qwen3:1.7b"]
-        )
+        got = preferred_or_installed_downgrade("qwen3:8b", ["qwen3:8b", "qwen3:4b", "qwen3:1.7b"])
         assert got == "qwen3:8b"
 
     def test_latest_tag_matches_bare_tag(self) -> None:
@@ -29,9 +27,7 @@ class TestPreferredOrInstalledDowngrade:
         assert got == "qwen3:8b"
 
     def test_downgrades_from_8b_to_4b_when_only_4b_installed(self) -> None:
-        got = preferred_or_installed_downgrade(
-            "qwen3:8b", ["qwen3:4b", "qwen3:1.7b"]
-        )
+        got = preferred_or_installed_downgrade("qwen3:8b", ["qwen3:4b", "qwen3:1.7b"])
         assert got == "qwen3:4b"
 
     def test_downgrades_from_8b_to_1p7b_when_nothing_else_installed(self) -> None:
@@ -45,15 +41,11 @@ class TestPreferredOrInstalledDowngrade:
         assert got == "qwen3:4b"
 
     def test_returns_none_when_no_qwen3_installed(self) -> None:
-        got = preferred_or_installed_downgrade(
-            "qwen3:8b", ["mistral:latest", "gemma3:9b"]
-        )
+        got = preferred_or_installed_downgrade("qwen3:8b", ["mistral:latest", "gemma3:9b"])
         assert got is None
 
     def test_returns_none_for_non_qwen3_preferred(self) -> None:
-        got = preferred_or_installed_downgrade(
-            "mistral:latest", ["qwen3:8b", "qwen3:1.7b"]
-        )
+        got = preferred_or_installed_downgrade("mistral:latest", ["qwen3:8b", "qwen3:1.7b"])
         assert got is None
 
     def test_empty_inputs(self) -> None:
@@ -76,7 +68,5 @@ class TestPreferredOrInstalledDowngrade:
         ("qwen3:32b", ["qwen3:14b"], "qwen3:14b"),
     ],
 )
-def test_downgrade_parametrised(
-    preferred: str, installed: list[str], expected: str
-) -> None:
+def test_downgrade_parametrised(preferred: str, installed: list[str], expected: str) -> None:
     assert preferred_or_installed_downgrade(preferred, installed) == expected

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -1,4 +1,5 @@
 """Tests for the study-load model-version allowlist."""
+
 from __future__ import annotations
 
 import pytest
@@ -16,16 +17,14 @@ from scripts.ai_assistant.ui import model_policy
         ("anthropic", "claude-opus-4-6-20251101"),
         ("google-genai", "gemini-3.1-pro"),
         ("google-genai", "gemini-3.2-pro"),
-        ("google-genai", "gemini-4-pro"),         # next major
+        ("google-genai", "gemini-4-pro"),  # next major
         ("openai", "gpt-5-3"),
         ("openai", "gpt-5-4-2026-01"),
         ("openai", "gpt-6"),
     ],
 )
 def test_allowed(provider: str, model: str) -> None:
-    res = model_policy.is_model_allowed_for_study_load(
-        provider=provider, model=model
-    )
+    res = model_policy.is_model_allowed_for_study_load(provider=provider, model=model)
     assert res.allowed, res.reason
 
 
@@ -33,22 +32,20 @@ def test_allowed(provider: str, model: str) -> None:
     "provider, model",
     [
         ("anthropic", "claude-opus-4-5-20251101"),  # below 4.6
-        ("anthropic", "claude-sonnet-4-6"),         # sonnet is not on allowlist
+        ("anthropic", "claude-sonnet-4-6"),  # sonnet is not on allowlist
         ("anthropic", "claude-haiku-4-5-20251001"),
-        ("google-genai", "gemini-2.5-pro"),         # below 3.1
-        ("google-genai", "gemini-3-pro"),           # parses as 3.0 — below 3.1
-        ("google-genai", "gemini-3-flash"),         # wrong family
-        ("openai", "gpt-4.1"),                      # below 5.3
-        ("openai", "gpt-5-2"),                      # below 5.3
+        ("google-genai", "gemini-2.5-pro"),  # below 3.1
+        ("google-genai", "gemini-3-pro"),  # parses as 3.0 — below 3.1
+        ("google-genai", "gemini-3-flash"),  # wrong family
+        ("openai", "gpt-4.1"),  # below 5.3
+        ("openai", "gpt-5-2"),  # below 5.3
         ("openai", "gpt-4o"),
-        ("", ""),                                   # no model selected
-        ("anthropic", ""),                          # no model selected
+        ("", ""),  # no model selected
+        ("anthropic", ""),  # no model selected
     ],
 )
 def test_blocked(provider: str, model: str) -> None:
-    res = model_policy.is_model_allowed_for_study_load(
-        provider=provider, model=model
-    )
+    res = model_policy.is_model_allowed_for_study_load(provider=provider, model=model)
     assert not res.allowed, res.reason
 
 

--- a/tests/test_pdf_phi_flag.py
+++ b/tests/test_pdf_phi_flag.py
@@ -15,16 +15,12 @@ class TestPDFPHIFreeOptIn:
         monkeypatch.delenv("REPORTALIN_PDF_PHI_FREE", raising=False)
         assert extract_pdf_data._pdf_phi_free_opt_in() is False
 
-    def test_true_for_accepted_values(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_true_for_accepted_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
         for value in ("1", "true", "TRUE", "yes", "YES", "on"):
             monkeypatch.setenv("REPORTALIN_PDF_PHI_FREE", value)
             assert extract_pdf_data._pdf_phi_free_opt_in() is True, value
 
-    def test_false_for_unrecognized(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_false_for_unrecognized(self, monkeypatch: pytest.MonkeyPatch) -> None:
         for value in ("0", "false", "", "maybe"):
             monkeypatch.setenv("REPORTALIN_PDF_PHI_FREE", value)
             assert extract_pdf_data._pdf_phi_free_opt_in() is False, value
@@ -37,9 +33,7 @@ class TestPDFPHIFreeAuthority:
         monkeypatch.setattr(config, "BASE_DIR", tmp_path)
         assert extract_pdf_data._pdf_phi_free_authority_present() is False
 
-    def test_absent_when_file_empty(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_absent_when_file_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(config, "BASE_DIR", tmp_path)
         (tmp_path / "authorities").mkdir()
         (tmp_path / "authorities" / "phi_free_pdfs.md").write_text("")
@@ -57,9 +51,7 @@ class TestPDFPHIFreeAuthority:
 
 
 class TestResolvePDFProviderGate:
-    def test_refuses_without_env_flag(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_refuses_without_env_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("REPORTALIN_PDF_PHI_FREE", raising=False)
         monkeypatch.setenv("LLM_PROVIDER", "anthropic")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake")
@@ -76,9 +68,7 @@ class TestResolvePDFProviderGate:
         monkeypatch.setenv("LLM_PROVIDER", "anthropic")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake")
         monkeypatch.setenv("LLM_MODEL", "claude-sonnet-4-20250514")
-        with pytest.raises(
-            ValueError, match=r"attestation note at .* is missing or empty"
-        ):
+        with pytest.raises(ValueError, match=r"attestation note at .* is missing or empty"):
             extract_pdf_data._resolve_pdf_provider()
 
     def test_refuses_with_flag_but_empty_authority(
@@ -91,9 +81,7 @@ class TestResolvePDFProviderGate:
         monkeypatch.setenv("LLM_PROVIDER", "anthropic")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake")
         monkeypatch.setenv("LLM_MODEL", "claude-sonnet-4-20250514")
-        with pytest.raises(
-            ValueError, match=r"attestation note at .* is missing or empty"
-        ):
+        with pytest.raises(ValueError, match=r"attestation note at .* is missing or empty"):
             extract_pdf_data._resolve_pdf_provider()
 
     def test_proceeds_with_flag_and_authority(

--- a/tests/test_phi_gate.py
+++ b/tests/test_phi_gate.py
@@ -40,10 +40,7 @@ class TestClinicalFreeText:
         assert phi_allowlist.is_clinical_free_text("patient expired") is True
 
     def test_died_notation(self) -> None:
-        assert (
-            phi_allowlist.is_clinical_free_text("died on 3/1/2014 due to complications")
-            is True
-        )
+        assert phi_allowlist.is_clinical_free_text("died on 3/1/2014 due to complications") is True
 
     def test_benign_prose_not_flagged(self) -> None:
         assert phi_allowlist.is_clinical_free_text("Enrolled in cohort A") is False
@@ -122,9 +119,7 @@ class TestPHIGateCheck:
     def test_real_name_in_clinical_narrative_still_warns(self) -> None:
         # Per-match allowlist must NOT swallow a real-name bigram just
         # because the surrounding text has clinical vocabulary.
-        result = phi_gate_check(
-            "Subject Rajesh Sharma was diagnosed with pulmonary TB."
-        )
+        result = phi_gate_check("Subject Rajesh Sharma was diagnosed with pulmonary TB.")
         assert result.blocked is False
         assert "PERSON_NAME_GENERIC" in result.findings
 
@@ -133,9 +128,7 @@ class TestPHIGateCheck:
         # bigrams the old whole-text allowlist let through.
         for label in ("Cohort A analysis", "Index Cases enrolled", "Household Contacts"):
             result = phi_gate_check(label)
-            assert "PERSON_NAME_GENERIC" not in result.findings, (
-                f"{label!r} incorrectly flagged"
-            )
+            assert "PERSON_NAME_GENERIC" not in result.findings, f"{label!r} incorrectly flagged"
 
     def test_violin_plot_heading_does_not_warn(self) -> None:
         # Narratives contain section headings like "Violin Plot",
@@ -143,9 +136,7 @@ class TestPHIGateCheck:
         # never produce PERSON_NAME_GENERIC findings.
         for heading in ("Violin Plot", "Multivariate Model", "Interaction Model"):
             result = phi_gate_check(heading)
-            assert "PERSON_NAME_GENERIC" not in result.findings, (
-                f"{heading!r} incorrectly flagged"
-            )
+            assert "PERSON_NAME_GENERIC" not in result.findings, f"{heading!r} incorrectly flagged"
 
 
 # ── kanon_gate ──────────────────────────────────────────────────────────────
@@ -158,9 +149,7 @@ class TestKAnonCheck:
             {"age_band": "45-49", "sex": "F", "district": "D2"},  # unique
             {"age_band": "45-49", "sex": "F", "district": "D2"},  # size 2
         ]
-        result = kanon_check(
-            rows, quasi_identifiers=("age_band", "sex", "district"), k=5
-        )
+        result = kanon_check(rows, quasi_identifiers=("age_band", "sex", "district"), k=5)
         assert result.blocked is True
         assert result.smallest_class_size == 1
 
@@ -263,17 +252,13 @@ class TestPhiSafeReturn:
 class TestGuardRowsWithKanon:
     def test_empty_rows_on_block(self) -> None:
         rows = [{"g": "A"}] * 2  # smaller than k=5
-        surfaced, result = guard_rows_with_kanon(
-            rows, quasi_identifiers=("g",), k=5
-        )
+        surfaced, result = guard_rows_with_kanon(rows, quasi_identifiers=("g",), k=5)
         assert surfaced == []
         assert result.blocked is True
 
     def test_passthrough_on_pass(self) -> None:
         rows = [{"g": "A"}] * 10
-        surfaced, result = guard_rows_with_kanon(
-            rows, quasi_identifiers=("g",), k=5
-        )
+        surfaced, result = guard_rows_with_kanon(rows, quasi_identifiers=("g",), k=5)
         assert len(surfaced) == 10
         assert result.blocked is False
 

--- a/tests/test_phi_scrub.py
+++ b/tests/test_phi_scrub.py
@@ -788,9 +788,7 @@ class TestScrubRowPriority:
             keep_fields=["^KEEP_ME$"],
             drop_fields=["^KEEP_ME$"],
         )
-        rows: list[dict[str, object]] = [
-            {"SUBJID": "S1", "KEEP_ME": "value-should-survive"}
-        ]
+        rows: list[dict[str, object]] = [{"SUBJID": "S1", "KEEP_ME": "value-should-survive"}]
         src = _seed_staging(monkeypatch_config, rows)
         phi_scrub.run_scrub(study_name="TEST")
         out = [json.loads(line) for line in src.read_text().splitlines() if line]

--- a/tests/test_pipeline_provenance.py
+++ b/tests/test_pipeline_provenance.py
@@ -28,20 +28,14 @@ class TestHashRawFile:
     def test_empty_file(self, tmp_path: Path) -> None:
         target = tmp_path / "empty.csv"
         target.write_bytes(b"")
-        assert (
-            dataset_pipeline.hash_raw_file(target)
-            == hashlib.sha256(b"").hexdigest()
-        )
+        assert dataset_pipeline.hash_raw_file(target) == hashlib.sha256(b"").hexdigest()
 
     def test_large_chunked(self, tmp_path: Path) -> None:
         # Force multiple chunks through the 64 KiB default.
         content = b"x" * ((1 << 16) * 3 + 1234)
         target = tmp_path / "big.bin"
         target.write_bytes(content)
-        assert (
-            dataset_pipeline.hash_raw_file(target)
-            == hashlib.sha256(content).hexdigest()
-        )
+        assert dataset_pipeline.hash_raw_file(target) == hashlib.sha256(content).hexdigest()
 
 
 class TestBuildProvenance:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -87,4 +87,3 @@ def test_dmy_variables_set() -> None:
     assert isinstance(DMY_VARIABLES, frozenset)
     assert "IC_VISDAT" in DMY_VARIABLES
     assert "IT_IGRADAT" in DMY_VARIABLES
-

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -6,6 +6,7 @@ runs) — *not* to ``STUDY_SNAPSHOTS_DIR`` (the tracked baseline at
 ``snapshots/{STUDY}/`` that the pipeline's PDF orchestrator falls back
 to). The two paths intentionally hold different things.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -16,9 +17,7 @@ from scripts.utils import snapshots
 
 
 @pytest.fixture
-def _isolated_trio(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> tuple[Path, Path]:
+def _isolated_trio(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
     """Build a tiny synthetic trio bundle + snapshot root under ``tmp_path``."""
     import config
 
@@ -28,9 +27,7 @@ def _isolated_trio(
     (trio / "dictionary").mkdir(parents=True)
     (trio / "pdfs").mkdir(parents=True)
     (trio / "variables.json").write_text('{"hello": "world"}', encoding="utf-8")
-    (trio / "datasets" / "1_demo.jsonl").write_text(
-        '{"row": 1}\n', encoding="utf-8"
-    )
+    (trio / "datasets" / "1_demo.jsonl").write_text('{"row": 1}\n', encoding="utf-8")
 
     monkeypatch.setattr(config, "TRIO_BUNDLE_DIR", trio)
     monkeypatch.setattr(config, "STUDY_RESTORE_POINTS_DIR", snaps)
@@ -60,9 +57,7 @@ def test_create_snapshot_rejects_bad_name(_isolated_trio: tuple[Path, Path]) -> 
         snapshots.create_snapshot(".hidden")
 
 
-def test_create_snapshot_requires_trio(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_create_snapshot_requires_trio(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     import config
 
     monkeypatch.setattr(config, "TRIO_BUNDLE_DIR", tmp_path / "does-not-exist")
@@ -186,9 +181,7 @@ class TestCli:
         assert len(names) == 1
         assert names[0].startswith("run-")
 
-    def test_create_with_name_override(
-        self, _isolated_trio: tuple[Path, Path]
-    ) -> None:
+    def test_create_with_name_override(self, _isolated_trio: tuple[Path, Path]) -> None:
         _, snaps = _isolated_trio
         rc = snapshots.main(["create", "--name", "cohort-a"])
         assert rc == 0
@@ -207,19 +200,16 @@ class TestCli:
         err = capsys.readouterr().err
         assert "already exists" in err
 
-    def test_create_with_force_overwrites(
-        self, _isolated_trio: tuple[Path, Path]
-    ) -> None:
+    def test_create_with_force_overwrites(self, _isolated_trio: tuple[Path, Path]) -> None:
         trio, snaps = _isolated_trio
         snapshots.main(["create", "--name", "cohort-a"])
         # Modify the trio bundle so the overwrite is observable.
         (trio / "variables.json").write_text('{"hello": "v2"}', encoding="utf-8")
         rc = snapshots.main(["create", "--name", "cohort-a", "--force"])
         assert rc == 0
-        assert (
-            (snaps / "cohort-a" / "variables.json").read_text(encoding="utf-8")
-            == '{"hello": "v2"}'
-        )
+        assert (snaps / "cohort-a" / "variables.json").read_text(
+            encoding="utf-8"
+        ) == '{"hello": "v2"}'
 
     def test_list_empty_and_populated(
         self, _isolated_trio: tuple[Path, Path], capsys: pytest.CaptureFixture[str]
@@ -238,9 +228,7 @@ class TestCli:
         assert "cohort-a" in out
         assert "cohort-b" in out
 
-    def test_restore_round_trip(
-        self, _isolated_trio: tuple[Path, Path]
-    ) -> None:
+    def test_restore_round_trip(self, _isolated_trio: tuple[Path, Path]) -> None:
         trio, _ = _isolated_trio
         snapshots.main(["create", "--name", "baseline"])
         # Corrupt the live trio bundle.

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -102,8 +102,12 @@ def test_theme_includes_hidden_end_chat_and_model_pill() -> None:
     chat_source = (_PROJECT_ROOT / "scripts/ai_assistant/ui/chat.py").read_text(encoding="utf-8")
     shell_source = (_PROJECT_ROOT / "scripts/ai_assistant/ui/shell.py").read_text(encoding="utf-8")
     web_ui_source = (_PROJECT_ROOT / "scripts/ai_assistant/web_ui.py").read_text(encoding="utf-8")
-    wizard_source = (_PROJECT_ROOT / "scripts/ai_assistant/ui/wizard.py").read_text(encoding="utf-8")
-    streaming_source = (_PROJECT_ROOT / "scripts/ai_assistant/ui/streaming.py").read_text(encoding="utf-8")
+    wizard_source = (_PROJECT_ROOT / "scripts/ai_assistant/ui/wizard.py").read_text(
+        encoding="utf-8"
+    )
+    streaming_source = (_PROJECT_ROOT / "scripts/ai_assistant/ui/streaming.py").read_text(
+        encoding="utf-8"
+    )
     assert ".st-key-rpln_end_chat_hidden" in css
     assert "rpln_composer_dock" in chat_source
     assert '[class*="st-key-rpln_composer_dock"]' in css
@@ -174,7 +178,9 @@ def test_theme_prunes_stale_pre_dock_composer_css() -> None:
 def test_streaming_loader_keeps_label_and_morphs_submit_icon() -> None:
     css = _CSS_PATH.read_text(encoding="utf-8")
     chat_source = (_PROJECT_ROOT / "scripts/ai_assistant/ui/chat.py").read_text(encoding="utf-8")
-    streaming_source = (_PROJECT_ROOT / "scripts/ai_assistant/ui/streaming.py").read_text(encoding="utf-8")
+    streaming_source = (_PROJECT_ROOT / "scripts/ai_assistant/ui/streaming.py").read_text(
+        encoding="utf-8"
+    )
     assert streaming_source.index("status = st.empty()") < streaming_source.index(
         "placeholder = st.empty()"
     )
@@ -272,7 +278,9 @@ def test_memory_branch_wins_against_conn_for_all_rungs_runtime_error() -> None:
     assert any(kw in all_rungs_fail_msg for kw in _MEMORY_KEYWORDS)
 
     # The actual classifier in streaming.py must therefore check MEMORY first.
-    streaming_source = (_PROJECT_ROOT / "scripts/ai_assistant/ui/streaming.py").read_text(encoding="utf-8")
+    streaming_source = (_PROJECT_ROOT / "scripts/ai_assistant/ui/streaming.py").read_text(
+        encoding="utf-8"
+    )
     mem_idx = streaming_source.index("elif any(kw in low for kw in _MEMORY_KEYWORDS):")
     conn_idx = streaming_source.index("elif any(kw in low for kw in _conn_keywords):")
     assert mem_idx < conn_idx, (
@@ -293,7 +301,9 @@ def test_error_card_persists_after_rerun() -> None:
     assistant answer, while setting a small session flag so ``chat.py`` can
     mark the saved assistant message as an error."""
 
-    streaming_src = (_PROJECT_ROOT / "scripts/ai_assistant/ui/streaming.py").read_text(encoding="utf-8")
+    streaming_src = (_PROJECT_ROOT / "scripts/ai_assistant/ui/streaming.py").read_text(
+        encoding="utf-8"
+    )
     chat_src = (_PROJECT_ROOT / "scripts/ai_assistant/ui/chat.py").read_text(encoding="utf-8")
 
     assert 'st.session_state["_rpln_stream_error"] = True' in streaming_src
@@ -320,7 +330,9 @@ def test_sanitize_file_refs_strips_paths_extensions_and_markers() -> None:
 
 
 def test_chat_message_renderer_has_no_artifact_download_panel() -> None:
-    streaming_src = (_PROJECT_ROOT / "scripts/ai_assistant/ui/streaming.py").read_text(encoding="utf-8")
+    streaming_src = (_PROJECT_ROOT / "scripts/ai_assistant/ui/streaming.py").read_text(
+        encoding="utf-8"
+    )
 
     assert "def _render_artifacts_panel" not in streaming_src
     assert "_append_artifact_bundle" not in streaming_src

--- a/tests/test_wizard_pdf_mode.py
+++ b/tests/test_wizard_pdf_mode.py
@@ -77,9 +77,7 @@ def test_run_pipeline_does_not_leak_session_state_extras(
 
     monkeypatch.setattr(wizard, "_ensure_phi_key", lambda: None)
     # Pre-existing PR-#16-era key shouldn't change behaviour.
-    monkeypatch.setattr(
-        wizard.st, "session_state", {"pdf_extraction_mode": "snapshot"}
-    )
+    monkeypatch.setattr(wizard.st, "session_state", {"pdf_extraction_mode": "snapshot"})
 
     captured: dict[str, Any] = {}
     monkeypatch.setattr(wizard.subprocess, "run", _stub_subprocess_run(captured))


### PR DESCRIPTION
## Summary
- Migrate ReAct agent from `langgraph.prebuilt.create_react_agent` to `langchain.agents.create_agent` (LangGraph 1.x stack); kwarg `prompt=` → `system_prompt=`.
- `ChatNVIDIA`: `max_tokens` → `max_completion_tokens`.
- Drop legacy `.xls` support from dictionary + dataset extraction (only `.xlsx` and `.csv` accepted); `xlrd` path removed.
- `pdf_pipeline`: explicit None-guard on `provider`/`model` before the capability gate, eliminating two `# type: ignore[arg-type]` comments.
- Repo-rename URL housekeeping (`RePORTaLiN-RAG` → `RePORT-AI-Portal`) in `pyproject.toml` and `README.md`.
- Makefile: `docs` and new `docs-quality` targets run through `uv run --frozen sphinx-build`.
- Remainder (~90% of diff volume): Black/Ruff mechanical reformatting — trailing commas, line splits, double quotes, parenthesized `with` syntax.

## Behavior changes worth noting
- Legacy `.xls` files are no longer accepted by the dictionary loader; they raise `ValueError`. If any team raw-input is still `.xls`, convert to `.xlsx` first.
- NVIDIA token kwarg switch is unverified by tests (no live NVIDIA API call in CI); will surface only at runtime.

## Test plan
- [x] `uv run --frozen pytest tests/` — 918 passed, 3 skipped
- [x] `uv run --frozen ruff check .` — All checks passed
- [x] `python -c "from scripts.ai_assistant import agent_graph"` — clean import
- [x] `langchain.agents.create_agent` signature verified to accept `model/tools/system_prompt/checkpointer`