### PR TITLE
Add release notes to Sphinx docs

### DIFF
--- a/docs/sphinx/developer_guide/contributing.rst
+++ b/docs/sphinx/developer_guide/contributing.rst
@@ -73,6 +73,9 @@ Coding Rules
 * Add tests when behavior changes.
 * Update docs when operator behavior, PHI handling, configuration, or
   verification claims change.
+* Add a release-note entry for every pull request unless the change is
+  purely internal and has no operator, reviewer, developer, or user
+  impact.
 * Use Ruff for linting and formatting; do not introduce Black, Flake8, or
   isort configuration.
 
@@ -88,6 +91,8 @@ and language rules.
 * Avoid hard-coded test counts unless the count is generated or checked.
 * Avoid line-number references to code; they drift quickly.
 * Keep IRB-facing claims tied to artifacts and tests.
+* Add release notes in :doc:`../release_notes`; write them for the
+  affected audience, not from the commit history.
 * Run ``make docs-quality`` before committing documentation changes.
 
 Adding A PHI Rule

--- a/docs/sphinx/developer_guide/documentation_style.rst
+++ b/docs/sphinx/developer_guide/documentation_style.rst
@@ -33,6 +33,9 @@ The project has two documentation surfaces:
 * ``docs/sphinx/`` is the documentation library. Put setup detail,
   privacy evidence, architecture, testing, operations, and contributor
   workflow here.
+* ``docs/sphinx/release_notes.rst`` is the release-note source. Add a
+  short entry for every pull request unless the change has no reader
+  impact.
 
 Do not add standalone Markdown packets or parallel documentation trees.
 If a topic needs detail, add or update a Sphinx page and link to it from
@@ -157,4 +160,6 @@ Before opening a documentation PR:
 3. Confirm every command and path still exists.
 4. Confirm every PHI or IRB claim names an implementation artifact or
    verification artifact.
-5. Run the freshness, Sphinx, and verification gates.
+5. Add or update :doc:`../release_notes` when the change affects users,
+   operators, reviewers, or developers.
+6. Run the freshness, Sphinx, and verification gates.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -62,6 +62,9 @@ Documentation Map
      - Architecture, source entry points, operational contracts, tests,
        decisions, and contribution workflow.
      - Basic user onboarding.
+   * - :doc:`release_notes`
+     - User-readable summaries of notable changes.
+     - Commit dumps or implementation history.
 
 Contents
 --------
@@ -83,6 +86,12 @@ Contents
    :caption: For Developers & Maintainers
 
    developer_guide/index
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Project Updates
+
+   release_notes
 
 Reference
 ---------

--- a/docs/sphinx/release_notes.rst
+++ b/docs/sphinx/release_notes.rst
@@ -1,0 +1,38 @@
+Release Notes
+=============
+
+Release notes are written for people who need to know what changed
+without reading commits. Keep entries short, current, and grouped by
+impact.
+
+Unreleased
+----------
+
+Added
+~~~~~
+
+* Added this release-notes page to the Sphinx documentation.
+* Added a contribution rule that every pull request should include a
+  user-readable release note unless the change is purely internal and
+  has no operator, reviewer, developer, or user impact.
+
+Changed
+~~~~~~~
+
+* Reworked the GitHub README as a minimal entry point that sends readers
+  to Sphinx for setup, IRB/auditor evidence, and developer detail.
+* Consolidated the Sphinx audience routing into the documentation
+  landing page.
+* Moved the IRB/auditor profile into Sphinx and removed the old
+  standalone Markdown dossier.
+
+Release Note Rules
+------------------
+
+* Write for the affected audience, not from the commit history.
+* Put the newest entries first.
+* Use ISO dates when an entry moves from ``Unreleased`` to a released
+  version.
+* Group entries under ``Added``, ``Changed``, ``Fixed``, ``Removed``,
+  ``Deprecated``, or ``Security``.
+* Link to the relevant Sphinx page when a reader needs detail.


### PR DESCRIPTION
## Summary
- Adds a Sphinx release notes page with current documentation changes under Unreleased.
- Links release notes from the Sphinx landing page.
- Updates contributing and documentation-style guidance so future PRs include release notes by default.

## Verification
- `uv run python scripts/lint_doc_freshness.py`
- `uv run ruff format --check .`
- `make docs-quality`

## Notes
- `make docs-quality` needed to run outside the sandbox because uv required access to its home-directory cache.
- No raw data paths were accessed.