### PR TITLE
Harden production readiness blockers

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   version-bump:
     name: Conventional commit version bump
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     if: >-
       !startsWith(github.event.head_commit.message, 'chore: bump version') &&
@@ -121,3 +121,19 @@ jobs:
           git diff --cached --quiet && exit 0
           git commit -m "chore: bump version ${{ steps.version.outputs.old_version }} -> ${{ steps.version.outputs.new_version }}"
           git push
+
+      - name: Build release artifacts
+        if: steps.bump.outputs.bump != 'none'
+        run: uv build
+
+      - name: Tag and publish GitHub release
+        if: steps.bump.outputs.bump != 'none'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.new_version }}
+        run: |
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+          gh release create "v${VERSION}" dist/* \
+            --title "v${VERSION}" \
+            --notes "Automated release for v${VERSION}."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+User-facing release notes live in `docs/sphinx/release_notes.rst`.
+
+## Unreleased
+
+- Added production auth-boundary checks, healthcheck deployment templates,
+  release tagging, root security/license files, restore-drill automation, and
+  production smoke checks.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Solomon S Joseph and Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ N := \033[0m
 	snapshot snapshot-study restore-study list-snapshots \
 	test test-all lint typecheck security ci verify release-check \
 	docs doc-freshness docs-quality docs-linkcheck docs-ci release-notes \
+	restore-drill chat-smoke \
 	clean nuke
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -270,6 +271,9 @@ snapshot: snapshot-study
 restore-study:
 	@$(PYTHON) -m scripts.utils.snapshots restore
 
+restore-drill:
+	@$(PYTHON) -m scripts.utils.restore_drill
+
 list-snapshots:
 	@$(PYTHON) -m scripts.utils.snapshots list
 
@@ -302,7 +306,11 @@ security:
 	@$(UV) run pip-audit
 	@printf "$(G)✓ Security audit passed$(N)\n"
 
-ci: lint typecheck test
+chat-smoke:
+	@$(PYTHON) -m pytest tests/test_production_smoke.py
+	@printf "$(G)✓ Chat smoke passed$(N)\n"
+
+ci: lint typecheck test-all chat-smoke
 	@printf "$(G)✓ All CI gates passed$(N)\n"
 
 verify:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Do not open a public issue for suspected PHI exposure, credential leakage, or
+an authentication bypass.
+
+Email the maintainer listed in `pyproject.toml` with:
+
+- affected version or commit SHA;
+- deployment mode, excluding secrets and PHI;
+- reproduction steps;
+- observed impact;
+- whether PHI, raw study files, API keys, or audit artifacts may be exposed.
+
+The maintainer should acknowledge security reports within 3 business days and
+coordinate disclosure after the affected study owner and privacy lead have been
+notified.
+
+## Supported Versions
+
+Only the latest tagged release and the current `main` branch receive security
+fixes. Deployments handling study data should pin to a tag, not an arbitrary
+commit.

--- a/deploy/nginx/report-ai-portal.conf.example
+++ b/deploy/nginx/report-ai-portal.conf.example
@@ -34,6 +34,20 @@ server {
         proxy_set_header X-Auth-Request-Redirect $request_uri;
     }
 
+    auth_request_set $report_ai_user $upstream_http_x_auth_request_user;
+
+    location = /healthz {
+        auth_request off;
+        access_log off;
+        proxy_pass http://127.0.0.1:8501/_stcore/health;
+    }
+
+    location = /csp-report {
+        auth_request off;
+        access_log /var/log/nginx/report-ai-portal-csp.log;
+        return 204;
+    }
+
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
@@ -50,6 +64,11 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-User $report_ai_user;
+        # Nginx does not read /etc/default files automatically. Replace this
+        # with the same long random value set as REPORT_AI_PROXY_SHARED_SECRET
+        # in the systemd EnvironmentFile.
+        proxy_set_header X-Report-AI-Proxy-Secret "replace-with-/etc/default/report-ai-portal-secret";
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_read_timeout 86400;

--- a/deploy/systemd/report-ai-portal-healthcheck.service.example
+++ b/deploy/systemd/report-ai-portal-healthcheck.service.example
@@ -1,0 +1,6 @@
+[Unit]
+Description=Restart RePORT AI Portal when Streamlit health is unhealthy
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -eu -c 'curl --fail --silent --show-error --max-time 5 http://127.0.0.1:8501/_stcore/health >/dev/null || systemctl restart report-ai-portal.service'

--- a/deploy/systemd/report-ai-portal-healthcheck.timer.example
+++ b/deploy/systemd/report-ai-portal-healthcheck.timer.example
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run RePORT AI Portal healthcheck every minute
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1min
+AccuracySec=15s
+Unit=report-ai-portal-healthcheck.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/report-ai-portal.env.example
+++ b/deploy/systemd/report-ai-portal.env.example
@@ -1,0 +1,3 @@
+# Copy to /etc/default/report-ai-portal and chmod 0600.
+STUDY_NAME=Indo-VAP
+REPORT_AI_PROXY_SHARED_SECRET=replace-with-a-long-random-secret

--- a/deploy/systemd/report-ai-portal.service.example
+++ b/deploy/systemd/report-ai-portal.service.example
@@ -11,7 +11,11 @@ WorkingDirectory=/opt/report-ai-portal
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Environment=LOG_FORMAT=json
 Environment=LOG_DIR=/var/log/report-ai-portal
-Environment=STUDY_NAME=Indo-VAP
+Environment=STREAMLIT_SERVER_ADDRESS=127.0.0.1
+Environment=STREAMLIT_SERVER_ENABLE_CORS=true
+Environment=STREAMLIT_SERVER_ENABLE_XSRF_PROTECTION=true
+Environment=REPORT_AI_AUTH_MODE=proxy
+EnvironmentFile=/etc/default/report-ai-portal
 ExecStart=/usr/local/bin/uv run --group web --group ai_assistant --group llm python main.py --web
 Restart=on-failure
 RestartSec=5
@@ -23,7 +27,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=/opt/report-ai-portal/data /opt/report-ai-portal/output /opt/report-ai-portal/tmp /var/log/report-ai-portal /home/report-ai/.config/report_ai_portal
+ReadWritePaths=/opt/report-ai-portal/data /opt/report-ai-portal/output /opt/report-ai-portal/tmp /var/log/report-ai-portal /var/lib/report-ai/.config/report_ai_portal
 UMask=0077
 
 [Install]

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -96,8 +96,9 @@ else:
 # -- Options for linkcheck builder -------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
 #
-# HHS.gov and several Indian government hosts (abdm.gov.in, icmr.nic.in)
-# return 403 to automated linkcheck user-agents or fail DNS intermittently.
+# HHS.gov, NIST CSRC, and several Indian government hosts
+# (abdm.gov.in, icmr.nic.in) return 403 to automated linkcheck user-agents
+# or fail DNS intermittently.
 # The Streamlit quickstart URL is a local dev endpoint, so it is unavailable
 # on GitHub Actions. Ignore those specific hosts rather than treating them as
 # broken links. See
@@ -107,6 +108,7 @@ linkcheck_ignore: list[str] = [
     r"^https://www\.hhs\.gov/hipaa/.*",
     r"^https://www\.hhs\.gov/ohrp/.*",
     r"^https://abdm\.gov\.in/.*",
+    r"^https://csrc\.nist\.gov/.*",
     r"^https://main\.icmr\.nic\.in/.*",
     r"^https://dl\.acm\.org/doi/.*",
     r"^http://localhost:8501/?$",

--- a/docs/sphinx/developer_guide/index.rst
+++ b/docs/sphinx/developer_guide/index.rst
@@ -67,6 +67,7 @@ Contents
 
    api_reference
    project_status
+   production_backlog
    documentation_style
 
 .. toctree::

--- a/docs/sphinx/developer_guide/production_backlog.rst
+++ b/docs/sphinx/developer_guide/production_backlog.rst
@@ -1,0 +1,53 @@
+Production Backlog
+==================
+
+This page stores production hardening items that are useful but not required
+for the current release gate. Revisit it during release planning.
+
+Supply Chain
+------------
+
+* Add Dependabot or Renovate for Python dependencies and GitHub Actions.
+* Emit a CycloneDX or SPDX SBOM on each GitHub Release.
+* Decide whether ``pip-audit`` findings may ever use an allow-list, or keep
+  the current fail-closed policy and document it explicitly.
+* Add CODEOWNERS for security-sensitive surfaces under ``scripts/security/``,
+  ``deploy/``, and IRB/auditor documentation.
+* Add issue and pull request templates, including a private security triage
+  path for suspected PHI exposure.
+
+Runtime Resilience
+------------------
+
+* Add hosted-LLM retry/backoff and circuit-breaker behavior for OpenAI,
+  Anthropic, Google, and NVIDIA provider calls.
+* Add per-session token, turn, and estimated-cost ceilings with operator
+  alerts for runaway agent loops.
+* Add provider-side spend alarms and document who owns them.
+* Add load and latency-regression checks with a concrete p95 target.
+
+Observability
+-------------
+
+* Ship an example remote log/error sink configuration such as Loki/Promtail or
+  Sentry, with the exact event names operators should alert on.
+* Roll up telemetry JSONL into daily usage, token, cost, and anomaly summaries.
+* Surface PHI redactor internal exceptions as a metric without leaking raw
+  event text.
+
+Data Retention
+--------------
+
+* Add a conversation retention command with max-age and max-count controls.
+* Decide whether reviewed snapshots should remain single-slot or rotate by
+  timestamp before overwrite.
+
+Deployment Packaging
+--------------------
+
+* Add an OCI image for immutable deployment where operators cannot rely on
+  ``uv sync`` against live package indexes.
+* Add a data-flow diagram in ``docs/sphinx/irb_auditor/`` showing browser,
+  proxy, Streamlit, local files, and hosted LLM provider egress.
+* Define SLO, uptime, and error-budget targets for deployments that need a
+  support contract.

--- a/docs/sphinx/developer_guide/production_readiness.rst
+++ b/docs/sphinx/developer_guide/production_readiness.rst
@@ -43,6 +43,10 @@ the dependency vulnerability audit. A dependency that cannot be audited
 because it is the local project package is acceptable; third-party
 vulnerability findings are not.
 
+The release workflow must tag immutable releases as ``vX.Y.Z`` and attach
+build artifacts to the GitHub Release. Deployments should pin to a tag, not
+to a moving branch.
+
 Deployment Boundary
 -------------------
 
@@ -64,6 +68,12 @@ For shared use, place the app behind a reverse proxy that provides:
 * WebSocket proxying for Streamlit sessions;
 * security headers at the proxy layer.
 
+Production services must set ``REPORT_AI_AUTH_MODE=proxy`` and a long random
+``REPORT_AI_PROXY_SHARED_SECRET`` through the deployment secret store. The
+proxy must set both ``X-Forwarded-User`` and
+``X-Report-AI-Proxy-Secret``. Missing or mismatched values stop the app before
+the PHI-capable UI renders.
+
 The repository includes starting templates:
 
 * ``deploy/nginx/report-ai-portal.conf.example`` — Nginx reverse proxy
@@ -71,6 +81,8 @@ The repository includes starting templates:
   headers.
 * ``deploy/systemd/report-ai-portal.service.example`` — Linux service
   unit with narrow writable paths and process hardening.
+* ``deploy/systemd/report-ai-portal-healthcheck.*.example`` — timer-driven
+  healthcheck that restarts the service when ``/_stcore/health`` fails.
 
 Review the examples before use. Replace hostnames, certificate paths,
 service users, writable paths, OAuth configuration, and CSP reporting
@@ -141,6 +153,12 @@ Restore drills are mandatory before production use:
 5. confirm the assistant reads the restored ``trio_bundle/`` and not
    ``data/snapshots/`` directly.
 
+Run the non-destructive automated drill before hand-off:
+
+.. code-block:: bash
+
+   make restore-drill
+
 Secret and Key Rotation
 -----------------------
 
@@ -192,5 +210,4 @@ External References
 -------------------
 
 * `Streamlit configuration <https://docs.streamlit.io/develop/api-reference/configuration/config.toml>`_
-* `Streamlit Kubernetes deployment guide <https://docs.streamlit.io/deploy/tutorials/kubernetes>`_
 * `OWASP Secure Headers Project <https://owasp.org/www-project-secure-headers/>`_

--- a/docs/sphinx/release_notes.rst
+++ b/docs/sphinx/release_notes.rst
@@ -11,6 +11,12 @@ Unreleased
 Added
 ~~~~~
 
+* Added production-readiness controls for proxy authentication, healthcheck
+  wiring, release tagging, restore-drill automation, and root security/license
+  governance files.
+* Added a production backlog page for deferred hardening items such as SBOMs,
+  dependency-update automation, hosted-LLM budget limits, remote log sinks,
+  conversation retention, and OCI packaging.
 * Added Makefile targets for Sphinx release notes, docs linkcheck, and
   docs CI parity.
 * Added this release-notes page to the Sphinx documentation.

--- a/scripts/ai_assistant/ui/auth.py
+++ b/scripts/ai_assistant/ui/auth.py
@@ -1,0 +1,89 @@
+"""Streamlit authentication boundary checks."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from ipaddress import ip_address
+
+import streamlit as st
+
+_LOCAL_USERS = {"127.0.0.1", "::1", "localhost"}
+
+
+@dataclass(frozen=True)
+class AuthResult:
+    ok: bool
+    user: str = ""
+    reason: str = ""
+
+
+def _header(headers: Mapping[str, str], name: str) -> str:
+    wanted = name.lower()
+    for key, value in headers.items():
+        if key.lower() == wanted:
+            return value.strip()
+    return ""
+
+
+def _local_ip(value: object | None) -> bool:
+    if not value:
+        return True
+    if not isinstance(value, str):
+        return True
+    host = value.strip().split(",", 1)[0].strip()
+    if host in _LOCAL_USERS:
+        return True
+    try:
+        parsed = ip_address(host)
+        return parsed.is_loopback or parsed.is_unspecified
+    except ValueError:
+        return False
+
+
+def evaluate_auth(
+    *,
+    headers: Mapping[str, str],
+    ip: object | None,
+    environ: Mapping[str, str] = os.environ,
+) -> AuthResult:
+    """Return whether the current request satisfies the configured auth boundary."""
+
+    mode = environ.get("REPORT_AI_AUTH_MODE", "local").strip().lower()
+    if mode == "local":
+        if _local_ip(ip):
+            return AuthResult(ok=True, user="local")
+        return AuthResult(False, reason=f"Local mode only accepts loopback clients ({ip!r}).")
+
+    if mode != "proxy":
+        return AuthResult(False, reason=f"Unsupported REPORT_AI_AUTH_MODE={mode!r}.")
+
+    user_header = environ.get("REPORT_AI_AUTH_USER_HEADER", "X-Forwarded-User")
+    secret_header = environ.get("REPORT_AI_AUTH_SECRET_HEADER", "X-Report-AI-Proxy-Secret")
+    expected_secret = environ.get("REPORT_AI_PROXY_SHARED_SECRET", "").strip()
+    if not expected_secret:
+        return AuthResult(False, reason="REPORT_AI_PROXY_SHARED_SECRET is required.")
+
+    if _header(headers, secret_header) != expected_secret:
+        return AuthResult(False, reason="Proxy shared secret is missing or invalid.")
+
+    user = _header(headers, user_header)
+    if not user:
+        return AuthResult(False, reason=f"{user_header} is missing.")
+    return AuthResult(ok=True, user=user)
+
+
+def enforce_auth_boundary() -> str:
+    """Fail closed before any PHI-capable UI renders."""
+
+    headers = getattr(st.context, "headers", {}) or {}
+    ip = getattr(st.context, "ip_address", None)
+    result = evaluate_auth(headers=headers, ip=ip)
+    if result.ok:
+        st.session_state["authenticated_user"] = result.user
+        return result.user
+
+    st.error("Authentication boundary failed. Contact the deployment operator.")
+    st.caption(result.reason)
+    st.stop()

--- a/scripts/ai_assistant/web_ui.py
+++ b/scripts/ai_assistant/web_ui.py
@@ -20,6 +20,7 @@ import streamlit as st
 
 import config
 from scripts.ai_assistant.ui import chat, shell, wizard
+from scripts.ai_assistant.ui.auth import enforce_auth_boundary
 from scripts.ai_assistant.ui.conversations import (
     _conversation_has_artifacts,
     _conversations_dir,
@@ -88,6 +89,7 @@ def main() -> None:
         initial_sidebar_state="expanded",
     )
 
+    enforce_auth_boundary()
     init_state()
     shell.inject_css()
     shell.install_bridge()

--- a/scripts/utils/restore_drill.py
+++ b/scripts/utils/restore_drill.py
@@ -1,0 +1,66 @@
+"""Non-destructive restore drill for the reviewed snapshot baseline."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import config
+from scripts.utils import snapshots
+
+
+def _copy_if_exists(source: Path, target: Path) -> None:
+    if source.is_dir():
+        shutil.copytree(source, target, symlinks=False)
+
+
+def run_restore_drill() -> None:
+    """Exercise snapshot restore against a temporary copy of production paths."""
+
+    live_trio = Path(config.TRIO_BUNDLE_DIR)
+    reviewed_snapshot = Path(config.STUDY_SNAPSHOTS_DIR)
+    if not snapshots.snapshot_exists():
+        raise snapshots.SnapshotError(f"Reviewed snapshot missing: {reviewed_snapshot}")
+    if not Path(config.PHI_KEY_PATH).is_file():
+        raise snapshots.SnapshotError(f"PHI key missing: {config.PHI_KEY_PATH}")
+
+    with tempfile.TemporaryDirectory(prefix="report-ai-restore-drill-") as tmp:
+        root = Path(tmp)
+        drill_trio = root / "trio_bundle"
+        drill_snapshot = root / "snapshot"
+        _copy_if_exists(live_trio, drill_trio)
+        shutil.copytree(reviewed_snapshot, drill_snapshot, symlinks=False)
+
+        old_trio = config.TRIO_BUNDLE_DIR
+        old_snapshot = config.STUDY_SNAPSHOTS_DIR
+        try:
+            config.TRIO_BUNDLE_DIR = drill_trio
+            config.STUDY_SNAPSHOTS_DIR = drill_snapshot
+            restored = snapshots.restore_snapshot()
+        finally:
+            config.TRIO_BUNDLE_DIR = old_trio
+            config.STUDY_SNAPSHOTS_DIR = old_snapshot
+
+        if not (restored / "variables.json").is_file() and not any(
+            (restored / "datasets").glob("*.jsonl")
+        ):
+            raise snapshots.SnapshotError("Restore drill produced an empty trio bundle.")
+
+
+def main() -> int:
+    try:
+        run_restore_drill()
+    except snapshots.SnapshotError as exc:
+        print(f"✗ Restore drill failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"✗ Restore drill crashed: {exc}", file=sys.stderr)
+        return 1
+    print("✓ Restore drill passed without modifying live data.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_auth_boundary.py
+++ b/tests/test_auth_boundary.py
@@ -1,0 +1,57 @@
+"""Authentication-boundary regression tests."""
+
+from __future__ import annotations
+
+from scripts.ai_assistant.ui.auth import evaluate_auth
+
+
+def test_local_mode_allows_loopback() -> None:
+    result = evaluate_auth(headers={}, ip="127.0.0.1", environ={})
+
+    assert result.ok
+    assert result.user == "local"
+
+
+def test_local_mode_allows_streamlit_test_context_ip() -> None:
+    result = evaluate_auth(headers={}, ip=object(), environ={})
+
+    assert result.ok
+
+
+def test_local_mode_rejects_remote_client() -> None:
+    result = evaluate_auth(headers={}, ip="203.0.113.5", environ={})
+
+    assert not result.ok
+    assert "loopback" in result.reason
+
+
+def test_proxy_mode_requires_shared_secret() -> None:
+    result = evaluate_auth(
+        headers={"X-Forwarded-User": "operator@example.org"},
+        ip="127.0.0.1",
+        environ={"REPORT_AI_AUTH_MODE": "proxy"},
+    )
+
+    assert not result.ok
+    assert "SHARED_SECRET" in result.reason
+
+
+def test_proxy_mode_requires_matching_secret_and_user() -> None:
+    env = {
+        "REPORT_AI_AUTH_MODE": "proxy",
+        "REPORT_AI_PROXY_SHARED_SECRET": "s3cret",
+    }
+
+    assert not evaluate_auth(
+        headers={"X-Report-AI-Proxy-Secret": "wrong", "X-Forwarded-User": "op"},
+        ip="127.0.0.1",
+        environ=env,
+    ).ok
+
+    result = evaluate_auth(
+        headers={"X-Report-AI-Proxy-Secret": "s3cret", "X-Forwarded-User": "op"},
+        ip="127.0.0.1",
+        environ=env,
+    )
+    assert result.ok
+    assert result.user == "op"

--- a/tests/test_production_smoke.py
+++ b/tests/test_production_smoke.py
@@ -1,0 +1,39 @@
+"""Production wiring smoke checks that avoid live LLM calls."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import config
+from scripts.ai_assistant.ui.auth import evaluate_auth
+
+
+def test_fixture_study_bundle_is_present(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = tmp_path / "output" / "Fixture" / "trio_bundle"
+    datasets = bundle / "datasets"
+    datasets.mkdir(parents=True)
+    (datasets / "1_fixture.jsonl").write_text('{"row": 1}\n', encoding="utf-8")
+    monkeypatch.setattr(config, "TRIO_BUNDLE_DIR", bundle)
+    monkeypatch.setattr(config, "TRIO_DATASETS_DIR", datasets)
+
+    assert Path(config.TRIO_BUNDLE_DIR).is_dir()
+    assert any(Path(config.TRIO_DATASETS_DIR).glob("*.jsonl"))
+
+
+def test_chat_auth_proxy_configuration_is_enforceable() -> None:
+    result = evaluate_auth(
+        headers={"X-Forwarded-User": "operator", "X-Report-AI-Proxy-Secret": "secret"},
+        ip="127.0.0.1",
+        environ={
+            "REPORT_AI_AUTH_MODE": "proxy",
+            "REPORT_AI_PROXY_SHARED_SECRET": "secret",
+        },
+    )
+
+    assert result.ok
+    assert result.user == "operator"

--- a/tests/test_restore_drill.py
+++ b/tests/test_restore_drill.py
@@ -1,0 +1,32 @@
+"""Restore-drill tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import config
+from scripts.utils.restore_drill import run_restore_drill
+
+
+def test_restore_drill_uses_temp_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trio = tmp_path / "output" / "Indo-VAP" / "trio_bundle"
+    snap = tmp_path / "data" / "snapshots" / "Indo-VAP"
+    key = tmp_path / "phi.key"
+    for root in (trio, snap):
+        (root / "datasets").mkdir(parents=True)
+        (root / "datasets" / "1_demo.jsonl").write_text('{"row": 1}\n', encoding="utf-8")
+        (root / "variables.json").write_text('{"ok": true}', encoding="utf-8")
+    key.write_text("not-a-real-key", encoding="utf-8")
+
+    monkeypatch.setattr(config, "TRIO_BUNDLE_DIR", trio)
+    monkeypatch.setattr(config, "STUDY_SNAPSHOTS_DIR", snap)
+    monkeypatch.setattr(config, "PHI_KEY_PATH", key)
+
+    run_restore_drill()
+
+    assert (trio / "variables.json").read_text(encoding="utf-8") == '{"ok": true}'


### PR DESCRIPTION
## Summary
- add fail-closed Streamlit auth boundary for production proxy mode, plus nginx/systemd templates for shared-secret proxy headers and health checks
- add release tagging/GitHub Release creation, root LICENSE/SECURITY/CHANGELOG artifacts, restore-drill automation, and chat-smoke CI coverage
- add Sphinx production backlog for deferred good-to-haves from the audit

## Verification
- make ci
- uv run python -m sphinx -W -b html docs/sphinx docs/sphinx/_build/html
- make restore-drill was attempted and correctly failed because this checkout has no reviewed snapshot at data/snapshots/Indo-VAP

## Notes
- Production proxy mode requires REPORT_AI_PROXY_SHARED_SECRET in /etc/default/report-ai-portal and the same value configured in nginx for X-Report-AI-Proxy-Secret.
