### PR TITLE
Harden production runtime controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ User-facing release notes live in `docs/sphinx/release_notes.rst`.
 ## Unreleased
 
 - Hardened production runtime controls for PHI log redaction, request rate
-  limiting, direct virtualenv service execution, and study-name resolution.
+  limiting, CSP enforcement, direct virtualenv service execution, and
+  study-name resolution.
 - Added production auth-boundary checks, healthcheck deployment templates,
   release tagging, root security/license files, restore-drill automation, and
   production smoke checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ User-facing release notes live in `docs/sphinx/release_notes.rst`.
 
 ## Unreleased
 
+- Hardened production runtime controls for PHI log redaction, request rate
+  limiting, direct virtualenv service execution, and study-name resolution.
 - Added production auth-boundary checks, healthcheck deployment templates,
   release tagging, root security/license files, restore-drill automation, and
   production smoke checks.

--- a/config.py
+++ b/config.py
@@ -54,6 +54,16 @@ def _get_env_bool(key: str, default: bool) -> bool:
     return value in {"1", "true", "yes", "on"}
 
 
+def production_mode_enabled() -> bool:
+    """Return True when production controls should fail closed."""
+
+    return (
+        _get_env_bool("REPORT_AI_PRODUCTION", False)
+        or _get_env_bool("REPORT_AI_REQUIRE_PHI_LOG_REDACTOR", False)
+        or str(_get_env("REPORT_AI_AUTH_MODE", "")).strip().lower() == "proxy"
+    )
+
+
 # ----------------------------------------------------------------------------
 # YAML CONFIG (config/config.yaml — optional overlay)
 # ----------------------------------------------------------------------------
@@ -123,9 +133,13 @@ TMP_DIR = BASE_DIR / "tmp"
 # ----------------------------------------------------------------------------
 
 
-def detect_study_name() -> str:
+def detect_study_name(*, strict: bool | None = None) -> str:
+    strict = production_mode_enabled() if strict is None else strict
     if not RAW_DATA_DIR.exists():
-        logger.warning("RAW_DATA_DIR missing → using default: %s", DEFAULT_DATASET_NAME)
+        msg = f"RAW_DATA_DIR missing: {RAW_DATA_DIR}"
+        if strict:
+            raise RuntimeError(msg)
+        logger.warning("%s → using default: %s", msg, DEFAULT_DATASET_NAME)
         return DEFAULT_DATASET_NAME
 
     try:
@@ -141,16 +155,27 @@ def detect_study_name() -> str:
             if (RAW_DATA_DIR / candidate / "datasets").is_dir():
                 return candidate
 
-        logger.warning("No valid study found → using default: %s", DEFAULT_DATASET_NAME)
+        msg = f"No valid study found under {RAW_DATA_DIR}"
+        if strict:
+            raise RuntimeError(msg)
+        logger.warning("%s → using default: %s", msg, DEFAULT_DATASET_NAME)
         return DEFAULT_DATASET_NAME
 
-    except Exception:
-        logger.warning("Study detection failed → fallback to default")
+    except OSError as exc:
+        if strict:
+            raise RuntimeError(f"Study detection failed under {RAW_DATA_DIR}") from exc
+        logger.warning("Study detection failed → fallback to default", exc_info=True)
         return DEFAULT_DATASET_NAME
 
 
 # ENV override ALWAYS wins
-STUDY_NAME = _get_env("STUDY_NAME", detect_study_name())
+_STUDY_NAME_ENV = _get_env("STUDY_NAME")
+if _STUDY_NAME_ENV:
+    if "/" in _STUDY_NAME_ENV or "\\" in _STUDY_NAME_ENV or _STUDY_NAME_ENV in {".", ".."}:
+        raise ValueError("STUDY_NAME must be a plain folder name, not a path")
+    STUDY_NAME = _STUDY_NAME_ENV
+else:
+    STUDY_NAME = detect_study_name()
 
 
 # ----------------------------------------------------------------------------
@@ -367,6 +392,8 @@ TELEMETRY_SINK = TELEMETRY_DIR / "events.jsonl"
 # Chat / agent
 AGENT_MAX_TOKENS: int = _get_env_int("AGENT_MAX_TOKENS", 16384)
 AGENT_TIMEOUT: int = _get_env_int("AGENT_TIMEOUT", 300)
+CHAT_RATE_LIMIT_WINDOW_SECONDS: int = _get_env_int("CHAT_RATE_LIMIT_WINDOW_SECONDS", 60)
+CHAT_RATE_LIMIT_MAX_TURNS: int = _get_env_int("CHAT_RATE_LIMIT_MAX_TURNS", 12)
 # Watchdog on the agent stream: raise TimeoutError if no chunk is produced
 # for this many seconds. Measures inter-chunk idle time, NOT total wall
 # clock — so slow-but-steady streams (long tool runs) stay alive. The E3

--- a/deploy/nginx/report-ai-portal-proxy-secret.conf.example
+++ b/deploy/nginx/report-ai-portal-proxy-secret.conf.example
@@ -1,0 +1,4 @@
+# Copy to /etc/nginx/snippets/report-ai-portal-proxy-secret.conf.
+# Set owner root:root and mode 0600. The value must match
+# REPORT_AI_PROXY_SHARED_SECRET in /etc/default/report-ai-portal.
+proxy_set_header X-Report-AI-Proxy-Secret "replace-with-a-long-random-secret";

--- a/deploy/nginx/report-ai-portal.conf.example
+++ b/deploy/nginx/report-ai-portal.conf.example
@@ -59,9 +59,9 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
-    # Streamlit uses inline runtime assets. Start in Report-Only, inspect
-    # browser reports, then promote a tested policy to Content-Security-Policy.
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data: blob:; connect-src 'self' ws: wss:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /csp-report" always;
+    # Streamlit uses inline runtime assets; tighten this baseline only after
+    # exercising the full wizard and chat workflow.
+    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: blob:; connect-src 'self' ws: wss:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /csp-report" always;
 
     location / {
         limit_req zone=report_ai_app burst=60 nodelay;

--- a/deploy/nginx/report-ai-portal.conf.example
+++ b/deploy/nginx/report-ai-portal.conf.example
@@ -7,6 +7,10 @@ map $http_upgrade $connection_upgrade {
     '' close;
 }
 
+limit_req_zone $binary_remote_addr zone=report_ai_auth:10m rate=30r/m;
+limit_req_zone $binary_remote_addr zone=report_ai_app:10m rate=120r/m;
+limit_req_status 429;
+
 server {
     listen 80;
     server_name report-ai.example.org;
@@ -27,6 +31,7 @@ server {
     error_page 401 = /oauth2/sign_in;
 
     location /oauth2/ {
+        limit_req zone=report_ai_auth burst=10 nodelay;
         proxy_pass http://127.0.0.1:4180;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -59,16 +64,14 @@ server {
     add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data: blob:; connect-src 'self' ws: wss:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /csp-report" always;
 
     location / {
+        limit_req zone=report_ai_app burst=60 nodelay;
         proxy_pass http://127.0.0.1:8501;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-User $report_ai_user;
-        # Nginx does not read /etc/default files automatically. Replace this
-        # with the same long random value set as REPORT_AI_PROXY_SHARED_SECRET
-        # in the systemd EnvironmentFile.
-        proxy_set_header X-Report-AI-Proxy-Secret "replace-with-/etc/default/report-ai-portal-secret";
+        include /etc/nginx/snippets/report-ai-portal-proxy-secret.conf;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_read_timeout 86400;

--- a/deploy/systemd/report-ai-portal.env.example
+++ b/deploy/systemd/report-ai-portal.env.example
@@ -1,3 +1,5 @@
 # Copy to /etc/default/report-ai-portal and chmod 0600.
 STUDY_NAME=Indo-VAP
 REPORT_AI_PROXY_SHARED_SECRET=replace-with-a-long-random-secret
+CHAT_RATE_LIMIT_WINDOW_SECONDS=60
+CHAT_RATE_LIMIT_MAX_TURNS=12

--- a/deploy/systemd/report-ai-portal.service.example
+++ b/deploy/systemd/report-ai-portal.service.example
@@ -14,9 +14,11 @@ Environment=LOG_DIR=/var/log/report-ai-portal
 Environment=STREAMLIT_SERVER_ADDRESS=127.0.0.1
 Environment=STREAMLIT_SERVER_ENABLE_CORS=true
 Environment=STREAMLIT_SERVER_ENABLE_XSRF_PROTECTION=true
+Environment=REPORT_AI_PRODUCTION=1
+Environment=REPORT_AI_REQUIRE_PHI_LOG_REDACTOR=1
 Environment=REPORT_AI_AUTH_MODE=proxy
 EnvironmentFile=/etc/default/report-ai-portal
-ExecStart=/usr/local/bin/uv run --group web --group ai_assistant --group llm python main.py --web
+ExecStart=/opt/report-ai-portal/.venv/bin/python main.py --web
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=30

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -97,7 +97,7 @@ else:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
 #
 # HHS.gov, NIST CSRC, and several Indian government hosts
-# (abdm.gov.in, icmr.nic.in, icmr.gov.in) return 403 to automated linkcheck user-agents
+# (abdm.gov.in, icmr.nic.in, icmr.gov.in, uidai.gov.in) return 403 to automated linkcheck user-agents
 # or fail DNS intermittently.
 # The Streamlit quickstart URL is a local dev endpoint, so it is unavailable
 # on GitHub Actions. Ignore those specific hosts rather than treating them as
@@ -109,6 +109,7 @@ linkcheck_ignore: list[str] = [
     r"^https://www\.hhs\.gov/ohrp/.*",
     r"^https://abdm\.gov\.in/.*",
     r"^https://csrc\.nist\.gov/.*",
+    r"^https://uidai\.gov\.in/.*",
     r"^https://main\.icmr\.nic\.in/.*",
     r"^https://www\.icmr\.gov\.in/.*",
     r"^https://dl\.acm\.org/doi/.*",

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -97,7 +97,7 @@ else:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
 #
 # HHS.gov, NIST CSRC, and several Indian government hosts
-# (abdm.gov.in, icmr.nic.in) return 403 to automated linkcheck user-agents
+# (abdm.gov.in, icmr.nic.in, icmr.gov.in) return 403 to automated linkcheck user-agents
 # or fail DNS intermittently.
 # The Streamlit quickstart URL is a local dev endpoint, so it is unavailable
 # on GitHub Actions. Ignore those specific hosts rather than treating them as
@@ -110,6 +110,7 @@ linkcheck_ignore: list[str] = [
     r"^https://abdm\.gov\.in/.*",
     r"^https://csrc\.nist\.gov/.*",
     r"^https://main\.icmr\.nic\.in/.*",
+    r"^https://www\.icmr\.gov\.in/.*",
     r"^https://dl\.acm\.org/doi/.*",
     r"^http://localhost:8501/?$",
 ]

--- a/docs/sphinx/developer_guide/production_backlog.rst
+++ b/docs/sphinx/developer_guide/production_backlog.rst
@@ -25,6 +25,15 @@ Runtime Resilience
   runaway agent loops.
 * Add provider-side spend alarms and document who owns them.
 * Add load and latency-regression checks with a concrete p95 target.
+* Replace the local filesystem pipeline lock with a distributed lock before
+  running multiple portal instances against shared output storage.
+
+Security Headers
+----------------
+
+* Wire a reachable CSP violation report sink for deployed Nginx environments.
+* Tighten Streamlit CSP allowances as framework runtime requirements permit,
+  especially inline script and eval allowances.
 
 Observability
 -------------
@@ -38,6 +47,8 @@ Observability
 Data Retention
 --------------
 
+* Decide whether production output bundles, audit files, and conversation logs
+  require application-layer encryption in addition to encrypted host volumes.
 * Add a conversation retention command with max-age and max-count controls.
 * Decide whether reviewed snapshots should remain single-slot or rotate by
   timestamp before overwrite.

--- a/docs/sphinx/developer_guide/production_backlog.rst
+++ b/docs/sphinx/developer_guide/production_backlog.rst
@@ -21,8 +21,8 @@ Runtime Resilience
 
 * Add hosted-LLM retry/backoff and circuit-breaker behavior for OpenAI,
   Anthropic, Google, and NVIDIA provider calls.
-* Add per-session token, turn, and estimated-cost ceilings with operator
-  alerts for runaway agent loops.
+* Add per-session token and estimated-cost ceilings with operator alerts for
+  runaway agent loops.
 * Add provider-side spend alarms and document who owns them.
 * Add load and latency-regression checks with a concrete p95 target.
 

--- a/docs/sphinx/developer_guide/production_readiness.rst
+++ b/docs/sphinx/developer_guide/production_readiness.rst
@@ -74,19 +74,43 @@ proxy must set both ``X-Forwarded-User`` and
 ``X-Report-AI-Proxy-Secret``. Missing or mismatched values stop the app before
 the PHI-capable UI renders.
 
+Production services must also set ``REPORT_AI_PRODUCTION=1`` and
+``REPORT_AI_REQUIRE_PHI_LOG_REDACTOR=1``. With those flags, missing or
+unreadable PHI redaction keys are startup failures, not warnings. Local
+developer runs may still warn and continue before the first study load
+provisions a key.
+
+The Nginx template applies conservative per-client request throttles. Keep
+the app-layer chat turn ceiling enabled as a second guard:
+``CHAT_RATE_LIMIT_MAX_TURNS`` requests per ``CHAT_RATE_LIMIT_WINDOW_SECONDS``.
+
 The repository includes starting templates:
 
 * ``deploy/nginx/report-ai-portal.conf.example`` — Nginx reverse proxy
   with OAuth2 Proxy hook, TLS redirect, WebSocket forwarding, and security
   headers.
+* ``deploy/nginx/report-ai-portal-proxy-secret.conf.example`` — root-only
+  Nginx snippet containing the proxy shared-secret header. Keep this outside
+  the broadly-readable site config and make it match
+  ``REPORT_AI_PROXY_SHARED_SECRET``.
 * ``deploy/systemd/report-ai-portal.service.example`` — Linux service
-  unit with narrow writable paths and process hardening.
+  unit with direct virtualenv execution, narrow writable paths, and process
+  hardening. Build the virtualenv during deployment, then start the service;
+  do not let systemd invoke ``uv run`` as the long-lived runtime.
 * ``deploy/systemd/report-ai-portal-healthcheck.*.example`` — timer-driven
   healthcheck that restarts the service when ``/_stcore/health`` fails.
 
 Review the examples before use. Replace hostnames, certificate paths,
 service users, writable paths, OAuth configuration, and CSP reporting
 endpoints for the deployed environment.
+
+Before enabling the systemd unit, install dependencies into the checked-out
+virtualenv:
+
+.. code-block:: bash
+
+   cd /opt/report-ai-portal
+   uv sync --frozen --group web --group ai_assistant --group llm
 
 Security Headers
 ----------------

--- a/docs/sphinx/developer_guide/production_readiness.rst
+++ b/docs/sphinx/developer_guide/production_readiness.rst
@@ -126,10 +126,10 @@ At minimum:
 * ``Permissions-Policy`` denying unused browser capabilities;
 * a tested ``Content-Security-Policy``.
 
-Streamlit uses inline runtime assets, so start CSP in
-``Content-Security-Policy-Report-Only`` mode, inspect reports while using
-the full wizard and chat workflow, then promote a verified policy to
-enforcement. Do not ship an untested enforcing CSP.
+The Nginx template ships an enforcing CSP baseline with Streamlit's required
+inline runtime allowances. Exercise the full wizard and chat workflow after
+proxy changes, inspect browser console and CSP reports, and add only exact
+origins required by the deployed environment.
 
 Monitoring
 ----------

--- a/docs/sphinx/release_notes.rst
+++ b/docs/sphinx/release_notes.rst
@@ -11,6 +11,9 @@ Unreleased
 Added
 ~~~~~
 
+* Added production fail-closed controls for PHI log redaction, app/proxy rate
+  limiting, direct virtualenv service execution, and stricter production study
+  resolution.
 * Added production-readiness controls for proxy authentication, healthcheck
   wiring, release tagging, restore-drill automation, and root security/license
   governance files.

--- a/docs/sphinx/release_notes.rst
+++ b/docs/sphinx/release_notes.rst
@@ -12,8 +12,8 @@ Added
 ~~~~~
 
 * Added production fail-closed controls for PHI log redaction, app/proxy rate
-  limiting, direct virtualenv service execution, and stricter production study
-  resolution.
+  limiting, CSP enforcement, direct virtualenv service execution, and stricter
+  production study resolution.
 * Added production-readiness controls for proxy authentication, healthcheck
   wiring, release tagging, restore-drill automation, and root security/license
   governance files.

--- a/main.py
+++ b/main.py
@@ -183,26 +183,31 @@ def _release_pipeline_lock() -> None:
 
 
 def _install_log_redactor_best_effort() -> None:
-    """Attach the PHI log-redaction filter to the root logger when the key exists.
+    """Attach the PHI log-redaction filter, failing closed in production.
 
-    **What.** Loads the sidecar HMAC key and installs the filter; silently
-    skips when the key is absent or unreadable.
+    **What.** Loads the sidecar HMAC key and installs the filter. Local/dev
+    runs warn and continue when the key is absent; production runs stop.
 
     **Why.** The redactor needs the same 32-byte secret that keys pseudonym
     generation, so subject-id HMAC tags in logs stay joinable with the
     on-disk pseudonyms for operators who hold the key. Entry points that
     run before the PHI key exists (fresh checkout / first chat session)
-    should still produce logs rather than hard-fail on a missing key.
+    should still produce logs rather than hard-fail on a missing key. Production
+    services must not run with PHI-capable logging unredacted.
 
     **How.** Calls :func:`scripts.security.phi_scrub.load_key`; on
     :class:`PHIKeyMissingError` / :class:`PHIKeyPermissionError` /
     :class:`PHIScrubError`, logs a one-line warning and returns without
-    installing. Successful installs are idempotent (the install helper
-    no-ops when a filter is already present).
+    installing unless production controls are enabled. Successful installs are
+    idempotent (the install helper no-ops when a filter is already present).
     """
     try:
         key = _load_phi_key()
     except (PHIKeyMissingError, PHIKeyPermissionError, PHIScrubError) as exc:
+        if config.production_mode_enabled():
+            raise RuntimeError(
+                "Production startup refused: PHI log redactor could not be installed."
+            ) from exc
         log.warning(
             "PHI log redactor NOT installed (%s). "
             "Use the web UI Load Study flow, or ask a developer/operator "

--- a/scripts/ai_assistant/cli.py
+++ b/scripts/ai_assistant/cli.py
@@ -347,6 +347,10 @@ def main() -> None:
             subject_id_patterns=list(SUBJECT_ID_PATTERNS),
         )
     except (PHIKeyMissingError, PHIKeyPermissionError, PHIScrubError) as exc:
+        if config.production_mode_enabled():
+            raise RuntimeError(
+                "Production startup refused: PHI log redactor could not be installed."
+            ) from exc
         logger.warning(
             "PHI log redactor NOT installed (%s). Use the web UI Load Study flow, "
             "or ask a developer/operator to provision the sidecar PHI key.",

--- a/scripts/ai_assistant/ui/chat.py
+++ b/scripts/ai_assistant/ui/chat.py
@@ -23,6 +23,41 @@ from scripts.ai_assistant.ui.providers import (
 logger = logging.getLogger(__name__)
 
 
+def _rate_limit_status(
+    timestamps: list[float],
+    *,
+    now: float,
+    window_seconds: int,
+    max_turns: int,
+) -> tuple[bool, list[float], int]:
+    """Return (allowed, retained_timestamps, retry_after_seconds)."""
+
+    window = max(window_seconds, 1)
+    limit = max(max_turns, 1)
+    retained = [ts for ts in timestamps if now - ts < window]
+    if len(retained) >= limit:
+        retry_after = max(1, int(window - (now - retained[0])))
+        return False, retained, retry_after
+    return True, [*retained, now], 0
+
+
+def _consume_turn_quota() -> str | None:
+    """Apply a per-session chat-turn ceiling before any LLM call."""
+
+    raw = st.session_state.get("rpln_turn_timestamps", [])
+    timestamps = [float(ts) for ts in raw if isinstance(ts, (int, float))]
+    allowed, retained, retry_after = _rate_limit_status(
+        timestamps,
+        now=datetime.now(UTC).timestamp(),
+        window_seconds=config.CHAT_RATE_LIMIT_WINDOW_SECONDS,
+        max_turns=config.CHAT_RATE_LIMIT_MAX_TURNS,
+    )
+    st.session_state["rpln_turn_timestamps"] = retained
+    if allowed:
+        return None
+    return f"Too many messages. Wait {retry_after}s before sending another request."
+
+
 # ---------------------------------------------------------------------------
 # Welcome hero
 # ---------------------------------------------------------------------------
@@ -218,6 +253,11 @@ def composer(assistant_slot: Any | None = None) -> None:
     question = pending or user_input
 
     if question and not pending_stream:
+        rate_limited = _consume_turn_quota()
+        if rate_limited:
+            st.warning(rate_limited)
+            return
+
         guard = guard_user_prompt(question)
         user_idx = len(ss.messages)
         user_content = question if guard.ok else "[PHI-REFUSED — content redacted]"

--- a/scripts/utils/log_hygiene.py
+++ b/scripts/utils/log_hygiene.py
@@ -24,10 +24,9 @@ Design constraints:
 * **Fast path for clean messages** — the filter short-circuits if the
   message contains none of the pre-compiled triggers, so the common
   case pays one substring search per record.
-* **Best-effort** — on any exception during redaction, the filter
-  passes the message through **as-is** rather than crashing the
-  pipeline. A raw-PHI leak in the log is bad; dropping all log output
-  is worse during an active extraction run.
+* **Fail-closed per record** — on any exception during redaction, the filter
+  replaces the message with a fixed redaction-failure notice. Logs remain
+  useful for operations without passing raw PHI through.
 
 IRB-grade benchmark anchors:
     * ICMR 2017 §11.5 audit + confidentiality
@@ -152,10 +151,9 @@ class PHIRedactingFilter(logging.Filter):
             # already-interpolated string.
             record.msg = redacted
             record.args = None
-        except Exception:  # noqa: S110 — best-effort: log emit must not abort pipeline
-            # Intentionally swallowed: a raw-PHI leak in a log is bad; aborting
-            # an active extraction run because the redactor crashed is worse.
-            pass
+        except Exception:
+            record.msg = "[PHI LOG REDACTION FAILURE - message suppressed]"
+            record.args = None
         return True
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,21 @@ class TestDetectStudyName:
         result = detect_study_name()
         assert result == config.DEFAULT_DATASET_NAME
 
+    def test_strict_missing_raw_dir_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(config, "RAW_DATA_DIR", tmp_path / "nonexistent")
+        with pytest.raises(RuntimeError, match="RAW_DATA_DIR missing"):
+            detect_study_name(strict=True)
+
+    def test_strict_no_valid_study_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "EmptyDir").mkdir()
+        monkeypatch.setattr(config, "RAW_DATA_DIR", tmp_path)
+        with pytest.raises(RuntimeError, match="No valid study"):
+            detect_study_name(strict=True)
+
 
 class TestGetEnvInt:
     def test_valid_int(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_log_hygiene.py
+++ b/tests/test_log_hygiene.py
@@ -109,7 +109,7 @@ class TestInstallPhiRedactor:
         assert not any("patient@example.com" in r.getMessage() for r in caplog.records)
 
 
-class TestBestEffortOnFailure:
+class TestRedactionFailureHandling:
     def test_malformed_format_args_do_not_crash(self, caplog: pytest.LogCaptureFixture) -> None:
         flt = log_hygiene.PHIRedactingFilter(hmac_key=TEST_KEY)
         logger = logging.getLogger("test_log_hygiene.errors")
@@ -117,8 +117,31 @@ class TestBestEffortOnFailure:
         logger.setLevel(logging.INFO)
         with caplog.at_level(logging.INFO, logger=logger.name):
             # Intentionally pass wrong number of args — getMessage() will
-            # raise internally; filter must fall through without aborting.
+            # raise internally; filter must suppress without aborting.
             logger.info("hello %s %s", "one")
         logger.removeFilter(flt)
         # A record was still emitted (not dropped).
         assert len(caplog.records) == 1
+
+    def test_internal_redaction_failure_suppresses_message(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class BrokenPattern:
+            def sub(self, repl: str, text: str) -> str:
+                raise RuntimeError("boom")
+
+        flt = log_hygiene.PHIRedactingFilter(
+            hmac_key=TEST_KEY,
+            generic_patterns=[("BROKEN", BrokenPattern())],  # type: ignore[list-item]
+        )
+        logger = logging.getLogger("test_log_hygiene.fail_closed")
+        logger.addFilter(flt)
+        logger.setLevel(logging.INFO)
+
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            logger.info("raw email patient@example.com")
+
+        logger.removeFilter(flt)
+        assert caplog.records[0].getMessage() == "[PHI LOG REDACTION FAILURE - message suppressed]"
+        assert "patient@example.com" not in caplog.text

--- a/tests/test_production_controls.py
+++ b/tests/test_production_controls.py
@@ -1,0 +1,59 @@
+"""Production-only fail-closed control tests."""
+
+from __future__ import annotations
+
+import pytest
+
+import config
+import main
+from scripts.ai_assistant.ui.chat import _rate_limit_status
+from scripts.security.phi_scrub import PHIKeyMissingError
+
+
+def test_phi_log_redactor_missing_key_fails_closed_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REPORT_AI_PRODUCTION", "1")
+
+    def _missing_key() -> bytes:
+        raise PHIKeyMissingError("missing")
+
+    monkeypatch.setattr(main, "_load_phi_key", _missing_key)
+
+    with pytest.raises(RuntimeError, match="Production startup refused"):
+        main._install_log_redactor_best_effort()
+
+
+def test_production_mode_is_enabled_by_proxy_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("REPORT_AI_PRODUCTION", raising=False)
+    monkeypatch.setenv("REPORT_AI_AUTH_MODE", "proxy")
+
+    assert config.production_mode_enabled()
+
+
+def test_chat_rate_limit_blocks_after_configured_turn_count() -> None:
+    allowed, retained, retry_after = _rate_limit_status(
+        [100.0, 110.0],
+        now=120.0,
+        window_seconds=60,
+        max_turns=2,
+    )
+
+    assert not allowed
+    assert retained == [100.0, 110.0]
+    assert retry_after == 40
+
+
+def test_chat_rate_limit_drops_old_timestamps() -> None:
+    allowed, retained, retry_after = _rate_limit_status(
+        [1.0, 50.0],
+        now=80.0,
+        window_seconds=60,
+        max_turns=2,
+    )
+
+    assert allowed
+    assert retained == [50.0, 80.0]
+    assert retry_after == 0


### PR DESCRIPTION
## Summary
- fail closed in production when PHI log redaction cannot be installed, while suppressing raw log records on internal redaction errors
- add per-session chat turn throttling plus Nginx rate limits for auth and app routes
- promote the Nginx template to an enforcing CSP baseline for production
- move the proxy shared secret into a root-only Nginx snippet and run systemd via the deployed virtualenv instead of `uv run`
- tighten production study-name detection and update release/readiness docs plus backlog notes

## Verification
- `make ci`
- `uv run --frozen --group docs sphinx-build -W -b html docs/sphinx docs/sphinx/_build/html`
- `uv run --frozen --group docs sphinx-build -b linkcheck docs/sphinx docs/sphinx/_build/linkcheck`

## Local caveat
- `make restore-drill` was attempted, but this checkout has no reviewed snapshot at `data/snapshots/Indo-VAP`, so the drill cannot run locally until that fixture/snapshot is present.