### PR TITLE
Fix proxy startup without raw study input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ User-facing release notes live in `docs/sphinx/release_notes.rst`.
 
 ## Unreleased
 
+- Fixed local ``make chat`` startup when another Streamlit process already
+  owns port 8501.
 - Fixed production/proxy startup when the deployment uses an explicit or
   default study name without raw study input mounted at import time.
 - Hardened production runtime controls for PHI log redaction, request rate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ User-facing release notes live in `docs/sphinx/release_notes.rst`.
 
 ## Unreleased
 
+- Fixed production/proxy startup when the deployment uses an explicit or
+  default study name without raw study input mounted at import time.
 - Hardened production runtime controls for PHI log redaction, request rate
   limiting, CSP enforcement, direct virtualenv service execution, and
   study-name resolution.

--- a/config.py
+++ b/config.py
@@ -64,6 +64,12 @@ def production_mode_enabled() -> bool:
     )
 
 
+def strict_study_detection_enabled() -> bool:
+    """Return True when missing auto-detected study data should abort import."""
+
+    return _get_env_bool("REPORT_AI_STRICT_STUDY_DETECTION", False)
+
+
 # ----------------------------------------------------------------------------
 # YAML CONFIG (config/config.yaml — optional overlay)
 # ----------------------------------------------------------------------------
@@ -134,7 +140,7 @@ TMP_DIR = BASE_DIR / "tmp"
 
 
 def detect_study_name(*, strict: bool | None = None) -> str:
-    strict = production_mode_enabled() if strict is None else strict
+    strict = strict_study_detection_enabled() if strict is None else strict
     if not RAW_DATA_DIR.exists():
         msg = f"RAW_DATA_DIR missing: {RAW_DATA_DIR}"
         if strict:

--- a/docs/sphinx/developer_guide/production_readiness.rst
+++ b/docs/sphinx/developer_guide/production_readiness.rst
@@ -80,6 +80,12 @@ unreadable PHI redaction keys are startup failures, not warnings. Local
 developer runs may still warn and continue before the first study load
 provisions a key.
 
+Set ``STUDY_NAME`` explicitly for deployments. Study auto-detection falls
+back to the default name when ``data/raw/`` is absent or the deployment uses
+only reviewed snapshots / scrubbed output. If an environment must fail when
+auto-detection cannot find raw study input, set
+``REPORT_AI_STRICT_STUDY_DETECTION=1``.
+
 The Nginx template applies conservative per-client request throttles. Keep
 the app-layer chat turn ceiling enabled as a second guard:
 ``CHAT_RATE_LIMIT_MAX_TURNS`` requests per ``CHAT_RATE_LIMIT_WINDOW_SECONDS``.

--- a/docs/sphinx/release_notes.rst
+++ b/docs/sphinx/release_notes.rst
@@ -42,6 +42,8 @@ Changed
 Fixed
 ~~~~~
 
+* Fixed local ``make chat`` startup when another Streamlit process already
+  owns port 8501.
 * Fixed production/proxy startup when the deployment uses an explicit or
   default study name without raw study input mounted at import time.
 * Updated a sandbox regression test so its expected output no longer

--- a/docs/sphinx/release_notes.rst
+++ b/docs/sphinx/release_notes.rst
@@ -42,6 +42,8 @@ Changed
 Fixed
 ~~~~~
 
+* Fixed production/proxy startup when the deployment uses an explicit or
+  default study name without raw study input mounted at import time.
 * Updated a sandbox regression test so its expected output no longer
   resembles a PHI phone-number pattern on Python 3.13.
 

--- a/docs/sphinx/user_guide/installation.rst
+++ b/docs/sphinx/user_guide/installation.rst
@@ -50,7 +50,9 @@ Start the Web UI
 
 ``make chat`` installs the web and AI Assistant dependency groups it
 needs, then opens a local Streamlit page. Use it to select the model
-provider, load a study, and start chat.
+provider, load a study, and start chat. If port ``8501`` is already in
+use, local startup chooses the next free port; production service units
+keep their configured fixed port.
 
 Optional Developer Setup
 ------------------------

--- a/main.py
+++ b/main.py
@@ -88,6 +88,7 @@ import contextlib
 import logging
 import os
 import shutil
+import socket
 import sys
 import time
 from collections.abc import Callable
@@ -125,6 +126,8 @@ __all__ = [
 ]
 
 _PIPELINE_LOCK_FILE: Any | None = None
+_STREAMLIT_DEFAULT_PORT = 8501
+_STREAMLIT_MAX_LOCAL_PORT = 8599
 
 
 def _acquire_pipeline_lock() -> None:
@@ -180,6 +183,43 @@ def _release_pipeline_lock() -> None:
         return
     _PIPELINE_LOCK_FILE.close()
     _PIPELINE_LOCK_FILE = None
+
+
+def _streamlit_port_available(host: str, port: int) -> bool:
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    try:
+        with socket.socket(family, socket.SOCK_STREAM) as sock:
+            sock.bind((host, port))
+    except OSError:
+        return False
+    return True
+
+
+def _local_streamlit_port(host: str) -> int:
+    for port in range(_STREAMLIT_DEFAULT_PORT, _STREAMLIT_MAX_LOCAL_PORT + 1):
+        if _streamlit_port_available(host, port):
+            return port
+    raise RuntimeError(
+        f"No free Streamlit port found in {_STREAMLIT_DEFAULT_PORT}-{_STREAMLIT_MAX_LOCAL_PORT}."
+    )
+
+
+def _streamlit_launch_command() -> list[str]:
+    cmd = [sys.executable, "-m", "streamlit", "run", "scripts/ai_assistant/web_ui.py"]
+    if config.production_mode_enabled() or os.environ.get("STREAMLIT_SERVER_PORT"):
+        return cmd
+
+    host = os.environ.get("STREAMLIT_SERVER_ADDRESS", "127.0.0.1").strip() or "127.0.0.1"
+    port = _local_streamlit_port(host)
+    cmd.extend(["--server.port", str(port)])
+    if port != _STREAMLIT_DEFAULT_PORT:
+        log.warning(
+            "Streamlit port %s is busy; launching local web UI on %s:%s.",
+            _STREAMLIT_DEFAULT_PORT,
+            host,
+            port,
+        )
+    return cmd
 
 
 def _install_log_redactor_best_effort() -> None:
@@ -993,10 +1033,7 @@ For detailed documentation, see the Sphinx docs or README.md
         )
         _install_log_redactor_best_effort()
         log.info("Launching Streamlit web UI…")
-        subprocess.run(
-            [sys.executable, "-m", "streamlit", "run", "scripts/ai_assistant/web_ui.py"],
-            check=True,
-        )
+        subprocess.run(_streamlit_launch_command(), check=True)  # noqa: S603
         return
 
     if getattr(args, "chat", False):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@ from config import (
     _get_env_int,
     detect_study_name,
     ensure_directories,
+    strict_study_detection_enabled,
 )
 
 
@@ -54,6 +55,26 @@ class TestDetectStudyName:
         monkeypatch.setattr(config, "RAW_DATA_DIR", tmp_path)
         with pytest.raises(RuntimeError, match="No valid study"):
             detect_study_name(strict=True)
+
+    def test_proxy_auth_does_not_make_detection_strict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "EmptyDir").mkdir()
+        monkeypatch.setattr(config, "RAW_DATA_DIR", tmp_path)
+        monkeypatch.setenv("REPORT_AI_AUTH_MODE", "proxy")
+        monkeypatch.delenv("REPORT_AI_STRICT_STUDY_DETECTION", raising=False)
+
+        assert detect_study_name() == config.DEFAULT_DATASET_NAME
+
+
+class TestStrictStudyDetection:
+    def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("REPORT_AI_STRICT_STUDY_DETECTION", raising=False)
+        assert not strict_study_detection_enabled()
+
+    def test_enabled_by_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("REPORT_AI_STRICT_STUDY_DETECTION", "1")
+        assert strict_study_detection_enabled()
 
 
 class TestGetEnvInt:

--- a/tests/test_production_controls.py
+++ b/tests/test_production_controls.py
@@ -33,6 +33,36 @@ def test_production_mode_is_enabled_by_proxy_auth(
     assert config.production_mode_enabled()
 
 
+def test_local_streamlit_launch_uses_next_free_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("REPORT_AI_PRODUCTION", raising=False)
+    monkeypatch.delenv("REPORT_AI_AUTH_MODE", raising=False)
+    monkeypatch.delenv("REPORT_AI_REQUIRE_PHI_LOG_REDACTOR", raising=False)
+    monkeypatch.delenv("STREAMLIT_SERVER_PORT", raising=False)
+    monkeypatch.setenv("STREAMLIT_SERVER_ADDRESS", "127.0.0.1")
+
+    def _available(host: str, port: int) -> bool:
+        return host == "127.0.0.1" and port == 8502
+
+    monkeypatch.setattr(main, "_streamlit_port_available", _available)
+
+    cmd = main._streamlit_launch_command()
+
+    assert cmd[-2:] == ["--server.port", "8502"]
+
+
+def test_production_streamlit_launch_keeps_fixed_configured_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REPORT_AI_PRODUCTION", "1")
+    monkeypatch.delenv("STREAMLIT_SERVER_PORT", raising=False)
+
+    cmd = main._streamlit_launch_command()
+
+    assert "--server.port" not in cmd
+
+
 def test_chat_rate_limit_blocks_after_configured_turn_count() -> None:
     allowed, retained, retry_after = _rate_limit_status(
         [100.0, 110.0],


### PR DESCRIPTION
## Summary
- decouple production/proxy fail-closed controls from fatal study auto-detection
- add explicit `REPORT_AI_STRICT_STUDY_DETECTION=1` for deployments that want missing raw study input to abort import
- fix local `make chat` when another Streamlit process already owns port 8501 by selecting the next free local port
- add regression tests for proxy auth with no valid `data/raw` study and local Streamlit port fallback
- update production/user docs and release notes

## Verification
- `REPORT_AI_AUTH_MODE=proxy uv run python -c "import config; print(config.STUDY_NAME); print(config.production_mode_enabled())"`
- `REPORT_AI_PRODUCTION=1 uv run python -c "import config; print(config.STUDY_NAME); print(config.production_mode_enabled())"`
- `REPORT_AI_STRICT_STUDY_DETECTION=1 uv run python -c "import config; print(config.STUDY_NAME)"` fails as intended
- `REPORT_AI_AUTH_MODE=proxy uv run python -c "import scripts.ai_assistant.web_ui; print('web import ok')"`
- `make chat` with 8501 occupied starts on 8502
- `uv run pytest tests/test_config.py tests/test_production_controls.py`
- `uv run --frozen --group docs sphinx-build -W -b html docs/sphinx docs/sphinx/_build/html`
- `make ci`